### PR TITLE
Switch to new Trickster emoji name

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -48,7 +48,7 @@ spirit_emoji_map = {
 'Stone': 'SpiritStoneUnyieldingDefiance',
 'Teeth': 'SpiritChompDevouringTeeth',
 'Thunderspeaker': 'SpiritThunderspeaker',
-'Trickster': 'SpiritGrinningTricksterStirsTrou',
+'Trickster': 'SpiritGrinningTrickster',
 'Vengeance': 'SpiritVengeanceBurningPlague',
 'Vigil': 'SpiritHearthVigil',
 'Voice': 'SpiritWanderingVoice',


### PR DESCRIPTION
Looks like this emoji was removed and replaced with a lighter colored icon a few months ago, around 2023-12-05

Example of the broken emoji failing to render:
https://discord.com/channels/846580409050857493/1213505829404413963/1214016733669625866
![image](https://github.com/nathanj/spirit-island-pbp/assets/1544971/4eb4bc34-18d5-4049-9814-b21101d2ff5a)


Autocomplete showing the new emoji name:
![image](https://github.com/nathanj/spirit-island-pbp/assets/1544971/980139dd-a51b-4e12-9140-c7b27314c8bf)

Note I haven't tested this in any way!
