### PR TITLE
allow selecting colour when adding a spirit

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -132,6 +132,12 @@ class Game(models.Model):
     def __str__(self):
         return str(self.id)
 
+    def available_colors(self):
+        colors = ['cyan', 'brown', 'blue', 'red', 'purple', 'orange', 'pink', 'yellow', 'green']
+        for player in self.gameplayer_set.all():
+            colors.remove(player.color)
+        return colors
+
 
 colors_to_circle_color_map = {
         'blue': '#705dff',

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -46,6 +46,12 @@
 	    <option value="{{spirit}}">{{spirit}}</option>
 	    {% endfor %}
 	  </select>
+	  <select name="color">
+	    <option value="random">Random color</option>
+	    {% for color in game.available_colors %}
+	    <option value="{{color}}">{{color.capitalize}}</option>
+	    {% endfor %}
+	  </select>
 	  <button type="submit" class="btn" >Add Spirit</button>
 	</form>
 

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -228,9 +228,7 @@ spirit_remove_cards = {
 
 def add_player(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
-    colors = ['cyan', 'brown', 'blue', 'red', 'purple', 'orange', 'pink', 'yellow', 'green']
-    for player in game.gameplayer_set.all():
-        colors.remove(player.color)
+    colors = game.available_colors()
     shuffle(colors)
     spirit_name = request.POST['spirit']
     aspect = None

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -229,7 +229,12 @@ spirit_remove_cards = {
 def add_player(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
     colors = game.available_colors()
-    shuffle(colors)
+    color = request.POST['color']
+    # this automatically handles random by virtue of random not being in colors.
+    # TODO: maybe consider showing an error if they select a color already in use?
+    if color not in colors:
+        shuffle(colors)
+        color = colors[0]
     spirit_name = request.POST['spirit']
     aspect = None
     if '-' in spirit_name:
@@ -241,7 +246,7 @@ def add_player(request, game_id):
     else:
         starting_energy = spirit_starting_energy[spirit.name]
 
-    gp = GamePlayer(game=game, spirit=spirit, color=colors[0], aspect=aspect, starting_energy=starting_energy)
+    gp = GamePlayer(game=game, spirit=spirit, color=color, aspect=aspect, starting_energy=starting_energy)
     gp.init_permanent_elements()
     gp.save()
     try:


### PR DESCRIPTION
Before this commit, the host has no choice, so colours are randomly
selected.

If specific colours are desired, then they have to ask an admin to
change the colours after the spirit is added.

Wouldn't it be nice to be able to specify the colour when adding the
spirit and not have to bother an admin?

---

A significant decision to be made is how two cases should be handled:

* a valid colour is submitted, but it is already in use
* a nonexistent or otherwise invalid colour is submitted

Right now these are all handled by simply randomly assigning the colour, but it may be more useful to show an error instead.

---

~~I'm still setting up my Python install so I haven't tested this yet. I would like to to fulfill my responsibility as a submitter, but I won't be offended if I'm beaten to the punch.~~ okay, everything in here appears to work