### PR TITLE
Fix energy bugs related to starting energy

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -286,7 +286,9 @@ class GamePlayer(models.Model):
         return sum([card.cost for card in self.play.all()])
 
     def get_gain_energy(self):
-        amount = max([self.starting_energy] + [p.get_energy() for p in self.presence_set.all()]) + sum([p.get_plus_energy() for p in self.presence_set.all()])
+        highest_energy = max([0] + [p.get_energy() for p in self.presence_set.all()])
+        additional_energy =  + sum([p.get_plus_energy() for p in self.presence_set.all()])
+        amount = highest_energy + additional_energy
         if self.aspect == 'Immense':
             return amount * 2
         elif self.aspect == 'Spreading Hostility':

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -243,7 +243,8 @@ def add_player(request, game_id):
     else:
         starting_energy = spirit_starting_energy[spirit.name]
 
-    gp = GamePlayer(game=game, spirit=spirit, color=colors[0], aspect=aspect, starting_energy=starting_energy)
+    # energy is intentionally set to starting_energy when adding a new player
+    gp = GamePlayer(game=game, spirit=spirit, color=colors[0], aspect=aspect, energy=starting_energy, starting_energy=starting_energy)
     gp.init_permanent_elements()
     gp.save()
     try:


### PR DESCRIPTION
- starting energy was unused when adding a player
- starting energy was incorrectly applied as a base for the maximum energy track uncovered, instead of simply `0`

https://discord.com/channels/846580409050857493/1222819603571408906/1261181957547753564