### PR TITLE
Fix posting red spirit logs to Discord

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -167,7 +167,9 @@ def adjust_msg(msg):
     try:
         for spirit in spirit_emoji_map:
             try:
-                msg = re.sub(f'^(.) {spirit} ', '\\1 ' + emoji_to_discord_map[spirit_emoji_map[spirit]] + ' ', msg)
+                # searches for keys from spirit_emoji_map and replaces with correct Discord emoji
+                # \\S+ matches the emoji representing the spirit; (.) does not successfully match ❤️
+                msg = re.sub(f'^(\\S+) {spirit} ', '\\1 ' + emoji_to_discord_map[spirit_emoji_map[spirit]] + ' ', msg)
             except KeyError:
                 pass
         match = re.search(r'''(\d+) energy''', msg)


### PR DESCRIPTION
The correct fix for #24; tested by copying messages from the PBP log and running them through the `adjust_msg` regex w/o `emoji_to_discord_map` (since my Discord bot isn't attached to the SI server).

💙 worked w/o changes; :heart: failed to match before changes, works after changes.