### PR TITLE
remove 1st presence from top track for Serpent Locus aspect

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -277,6 +277,11 @@ def add_player(request, game_id):
             try: elements = presence[4]
             except: elements = ''
             gp.presence_set.create(left=presence[0], top=presence[1], opacity=presence[2], energy=energy, elements=elements)
+
+        # remove 1 presence from top track for Serpent Locus setup
+        if aspect == 'Locus':
+            bonus_presence = spirit_presence[spirit.name][0]
+            toggle_presence(request, player_id=gp.pk, left=bonus_presence[0], top=bonus_presence[1])
     except Exception as ex:
         print(ex)
         pass


### PR DESCRIPTION
put the logic immediately after the presence is setup on the board for the newly created spirit

tested base Serpent and the Locus aspect after this change; don't see any other aspects needing this change