### PR TITLE
add IDs to the two screenshots

### DIFF
--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -9,13 +9,13 @@
 
 	{% if game.screenshot %}
 	<a href="{{ game.screenshot.url }}">
-	  <img src="{{ game.screenshot.url }}" class="img-fluid" />
+	  <img src="{{ game.screenshot.url }}" class="img-fluid" id="ss1" />
 	</a>
 	{% endif %}
 
 	{% if game.screenshot2 %}
 	<a href="{{ game.screenshot2.url }}">
-	  <img src="{{ game.screenshot2.url }}" class="img-fluid" />
+	  <img src="{{ game.screenshot2.url }}" class="img-fluid" id="ss2" />
 	</a>
 	{% endif %}
 


### PR DESCRIPTION
From @petertseng; source: https://github.com/nathanj/spirit-island-pbp/pull/40

Intended purpose:
A player can now add #ss2 to the page URL to scroll to screenshot 2. This is useful in games where the host puts the island in screenshot 2 (and a number of hosts do, in fact, do this).

There's not as much point in adding #ss1 to scroll to the first image, but it feels like it should be there for consistency?

This feature is currently unannounced/unadvertised. Players only know about it if they inspect the HTML or read this commit message. Not yet decided how to spread knowledge of it.

Abbreviations ss1 and ss2 instead of screenshot1 and screenshot2 because at this moment these would only be used by a player manually typing `#ss2`, so there is a benefit in keeping it short.