### PR TITLE
give Intensify Shifting Memory of Ages a permanent moon

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -292,6 +292,8 @@ class GamePlayer(models.Model):
     def init_permanent_elements(self):
         if self.aspect == 'DarkFire':
             self.permanent_moon += 1
+        elif self.aspect == 'Intensify':
+            self.permanent_moon += 1
 
     def full_name(self):
         name = self.spirit.name


### PR DESCRIPTION
This is a player convenience. The aspect grants a permanent moon, and Dark Fire Shadows has established that permanent elements are the way that has been decided to represent elements that are granted by aspects. If the website doesn't automatically do this, the player is going to do it anyway for sure, so might as well do it for them.

I'm a little unsatisfied with doing it this way because it's then possible for a player to accidentally decrement the permanent moon, losing something they should not be able to lose.

However, the alternative (create a presence object granting that element with starting opacity 0) also has the disadvantage that a player might accidentally click it, with the same consequences.

So I think it's best to ignore my dissatisfaction for now.