### PR TITLE
implement Dark Fire Shadows' permanent moon with presence

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -290,8 +290,7 @@ class GamePlayer(models.Model):
     def animal(self): return self.elements[Elements.Animal]
 
     def init_permanent_elements(self):
-        if self.aspect == 'DarkFire':
-            self.permanent_moon += 1
+        pass
 
     def full_name(self):
         name = self.spirit.name

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -288,6 +288,11 @@ def add_player(request, game_id):
         if aspect == 'Locus':
             bonus_presence = spirit_presence[spirit.name][0]
             toggle_presence(request, player_id=gp.pk, left=bonus_presence[0], top=bonus_presence[1])
+        elif aspect == 'DarkFire':
+            # Permanent moon
+            # (the presence is positioned such that it would be at the circled spot on the aspect card,
+            # but the aspect card is actually on top of it so it's unclickable and therefore permanent)
+            gp.presence_set.create(left=273, top=495, opacity=0.0, energy='', elements='Moon')
     except Exception as ex:
         print(ex)
         pass


### PR DESCRIPTION
Before this change, it's possible for the player to accidentally decrement their permanent moon and lose it.

With this change, the advantage is that this feels more in line with other bonus elements granted by the track: The player is always entitled to them and cannot accidentally lose them due to misclick.

No migration is needed for existing games with a Dark Fire Shadows because both init_permanent_elements and add_player are only run on player creation. Existing instances of Dark Fire Shadows continue to use permanent_elements and don't get this new invisible presence. Only new instances of Dark Fire Shadows get this.

---

Author's notes: This isn't really necessary; the status quo code (using permanent_elements) works fine. This just feels more in line with other track elements, so I'm sending it in as a proposal. But ultimately this is fixing something that isn't actually broken.