### PR TITLE
fail loudly if any card has duplicate elements, or allow them if DOUBLE_ELEMENT_CARDS env var is set

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,12 @@
 # Goto https://discord.com/developers/applications - YourBot - Bot - Token - Reveal
 DISCORD_KEY="insert bot token here"
 
+# Normally, power cards cannot have multiple of the same element,
+# and the site will enforce that this is true on startup.
+# To allow custom cards that do have multiple of the same element,
+# set this to any truthy value.
+DOUBLE_ELEMENT_CARDS = ""
+
 #Keep bot in debug mode if you are testing usually. Used in island/settings.py
 DEBUG="yes" 
 

--- a/pbf/apps.py
+++ b/pbf/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+import os
 
 
 class PbfConfig(AppConfig):
@@ -6,13 +7,14 @@ class PbfConfig(AppConfig):
     name = 'pbf'
 
     def ready(self):
-        self.assert_no_double_element_cards()
+        if not os.environ.get('DOUBLE_ELEMENT_CARDS', ''):
+            self.assert_no_double_element_cards()
 
     def assert_no_double_element_cards(self):
         # As of Nature Incarnate, there is no card published that has more than one of any element.
         # Therefore, to avoid any data entry error, we check for this and fail loudly if one is found.
         # If there were to be one in the future, either remove or modify this function.
-        # Also be sure to change get_elements in the Card model.
+        # Also see the environment variable setting DOUBLE_ELEMENT_CARDS that disables this check.
 
         from .models import Card
         for card in Card.objects.all():

--- a/pbf/apps.py
+++ b/pbf/apps.py
@@ -4,3 +4,20 @@ from django.apps import AppConfig
 class PbfConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'pbf'
+
+    def ready(self):
+        self.assert_no_double_element_cards()
+
+    def assert_no_double_element_cards(self):
+        # As of Nature Incarnate, there is no card published that has more than one of any element.
+        # Therefore, to avoid any data entry error, we check for this and fail loudly if one is found.
+        # If there were to be one in the future, either remove or modify this function.
+        # Also be sure to change get_elements in the Card model.
+
+        from .models import Card
+        for card in Card.objects.all():
+            if not card.elements:
+                continue
+            elements = card.elements.split(',')
+            if len(elements) != len(set(elements)):
+                raise ValueError(f"card {card} has duplicate elements")

--- a/pbf/models.py
+++ b/pbf/models.py
@@ -101,8 +101,9 @@ class Card(models.Model):
             if len(e) > 0:
                 # As of Nature Incarnate, there is no card published that has more than one of any element.
                 # By default, this fact is checked on startup (in apps.py) to avoid any data entry error.
-                # If there were to be one in the future, this code will need to change to accept it.
-                counter[Elements[e]] = 1
+                # Environment variable DOUBLE_ELEMENT_CARDS can be used to disable this check.
+                # This code already supports it as well, so as to not require changes on any future content that might do this.
+                counter[Elements[e]] += 1
         return counter
 
     def thresholds(self, elements, equiv_elements=None):

--- a/pbf/models.py
+++ b/pbf/models.py
@@ -99,6 +99,9 @@ class Card(models.Model):
         counter = Counter()
         for e in self.elements.split(','):
             if len(e) > 0:
+                # As of Nature Incarnate, there is no card published that has more than one of any element.
+                # By default, this fact is checked on startup (in apps.py) to avoid any data entry error.
+                # If there were to be one in the future, this code will need to change to accept it.
                 counter[Elements[e]] = 1
         return counter
 

--- a/pbf/models.py
+++ b/pbf/models.py
@@ -1095,6 +1095,9 @@ class Presence(models.Model):
             return counter
         for e in self.elements.split(','):
             if len(e) > 0:
+                # There exists at least one spirit that has a track space that gives two of the same element
+                # (Downpour Drenches the World with its 2 Water space)
+                # therefore, += is correct and necessary here.
                 counter[Elements[e]] += 1
         return counter
 


### PR DESCRIPTION
This avoids data-entry errors, and provides future-proofing.

Currently the code makes an unenforced assumption about released material (namely that no card has duplicate elements).

If we do not enforce the assumption, someone attempting to add a future card that has two of any element will observe the site silently do the wrong thing, or worse, they will not notice at all.

By enforcing the assumption and erroring if it's violated, we future-proof the site. Now the site will error, and by searching for the
error message in the codebase, they'll be led to the accompanying function and comment that explains what needs to be changed. They'll make the change and their new card will work as they expect.

closes https://github.com/nathanj/spirit-island-pbp/issues/39