### PR TITLE
Show prepared/added this turn indicators for Unconstrained Fangs

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -247,6 +247,12 @@ class GamePlayer(models.Model):
     ROT_GAINED_THIS_TURN = 1 << 2 # Whether they've gained from their track (NOT incrementing using the +1 button)
     ROT_CONVERTED_THIS_TURN = 1 << 3
 
+    def spirit_specific_incremented_this_turn(self):
+        return self.spirit_specific_per_turn_flags & GamePlayer.SPIRIT_SPECIFIC_INCREMENTED_THIS_TURN
+
+    def spirit_specific_decremented_this_turn(self):
+        return self.spirit_specific_per_turn_flags & GamePlayer.SPIRIT_SPECIFIC_DECREMENTED_THIS_TURN
+
     def rot_gained_this_turn(self):
         return self.spirit_specific_per_turn_flags & GamePlayer.ROT_GAINED_THIS_TURN
 

--- a/pbf/templates/energy.html
+++ b/pbf/templates/energy.html
@@ -49,6 +49,17 @@
         {% endif %}
       {% endfor %}
 
+      {% if player.aspect == 'Unconstrained' %}
+        {# intentionally do not block the player from making changes (in case of mistakes) #}
+        {# just show the indicators #}
+        {% if player.spirit_specific_incremented_this_turn %}
+          Prepared this turn!
+        {% endif %}
+        {% if player.spirit_specific_decremented_this_turn %}
+          Added to board this turn!
+        {% endif %}
+      {% endif %}
+
       {% if player.spirit.name == 'Rot' %}
         {% if player.rot_gained_this_turn %}
           Gained!


### PR DESCRIPTION
Helps remind the player that they've taken the action and shouldn't take the opposite one (but doesn't actually block them from doing so, in case they misclick)