### PR TITLE
group spirits by expansion and show their full names in spirit dropdown

### DIFF
--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -56,9 +56,9 @@
       {% for expansion, spirits in spirits_by_expansion.items %}
       <optgroup label="{{expansion}}">
         {% for spirit in spirits %}
-        <option value="{{spirit.0}}">{{spirit.0}}</option>
+        <option value="{{spirit.0}}">{{spirit.1}}</option>
         {% for aspect in spirit.2 %}
-        <option value="{{spirit.0}} - {{aspect}}">{{spirit.0}} [{{aspect}}]</option>
+        <option value="{{spirit.0}} - {{aspect}}">{{spirit.1}} [{{aspect}}]</option>
         {% endfor %}
         {% endfor %}
       </optgroup>

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -51,11 +51,19 @@
 
 	<form method="post" action="{% url 'add_player' game.id %}">
 	  {% csrf_token %}
-	  <select name="spirit">
-	    {% for spirit in spirits %}
-	    <option value="{{spirit}}">{{spirit}}</option>
-	    {% endfor %}
-	  </select>
+
+    <select name="spirit">
+      {% for expansion, spirits in spirits_by_expansion.items %}
+      <optgroup label="{{expansion}}">
+        {% for spirit in spirits %}
+        <option value="{{spirit.0}}">{{spirit.0}}</option>
+        {% for aspect in spirit.2 %}
+        <option value="{{spirit.0}} - {{aspect}}">{{spirit.0}} [{{aspect}}]</option>
+        {% endfor %}
+        {% endfor %}
+      </optgroup>
+      {% endfor %}
+    </select>
 	  <select name="color">
 	    <option value="random">Random color</option>
 	    {% for color in game.available_colors %}

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -417,8 +417,6 @@ def view_game(request, game_id):
             ('Exploratory Bringer', 'Bringer of Dreams and Nightmares [Exploratory]', ()),
         ],
     }
-    for spirits in spirits_by_expansion.values():
-        spirits.sort()
     spirits_present = [spirit for (expansion, spirits) in spirits_by_expansion.items() for (spirit, _, _) in spirits]
     spirits = [s.name for s in Spirit.objects.order_by('name').all()]
 

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -345,42 +345,94 @@ def view_game(request, game_id):
                 add_log_msg(game, text=f'New screenshot uploaded.', images='.' + game.screenshot2.url)
                 return redirect(reverse('view_game', args=[game.id]))
 
+    spirits_by_expansion = {
+        # Short name, full name, aspects (if any)
+        # Within an expansion, sorted alphabetically
+        #
+        # Should we sort by complexity?
+        # Don't think so; not everyone knows the complexities by heart,
+        # and so the ordering would look haphazard to those who don't know them.
+        #
+        # Similarly, aspects are going to be grouped with their spirit
+        # regardless of which expansion the aspect was released in,
+        # because not everyone is going to know which expansion has which aspects.
+        'Spirit Island (base)': [
+            ('Bringer', 'Bringer of Dreams and Nightmares', ('Enticing', 'Violence')),
+            ('Lightning', "Lightning's Swift Strike", ('Immense', 'Pandemonium', 'Sparking', 'Wind')),
+            ('Ocean', "Ocean's Hungry Grasp", ('Deeps',)),
+            ('River', 'River Surges in Sunlight', ('Haven', 'Sunshine', 'Travel')),
+            ('Shadows', 'Shadows Flicker Like Flame', ('Amorphous', 'DarkFire', 'Foreboding', 'Madness', 'Reach')),
+            ('Green', 'A Spread of Rampant Green', ('Regrowth', 'Tangles')),
+            ('Thunderspeaker', 'Thunderspeaker', ('Tactician', 'Warrior')),
+            ('Earth', 'Vital Strength of the Earth', ('Might', 'Resilience', 'Nourishing')),
+        ],
+        'Branch & Claw': [
+            ('Keeper', 'Keeper of the Forbidden Wilds', ('Spreading Hostility',)),
+            ('Fangs', 'Sharp Fangs Behind the Leaves', ('Encircle', 'Unconstrained')),
+        ],
+        'Jagged Earth': [
+            ('Fractured', 'Fractured Days Split the Sky', ()),
+            ('Trickster', 'Grinning Trickster Stirs Up Trouble', ()),
+            ('Lure', 'Lure of the Deep Wilderness', ('Lair',)),
+            ('Minds', 'Many Minds Move as One', ()),
+            ('Shifting', 'Shifting Memory of Ages', ('Intensify', 'Mentor')),
+            ('Mist', 'Shroud of Silent Mist', ('Stranded',)),
+            ('Starlight', 'Starlight Seeks Its Form', ()),
+            ('Stone', "Stone's Unyielding Defiance", ()),
+            ('Vengeance', 'Vengeance as a Burning Plague', ()),
+            ('Volcano', 'Volcano Looming High', ()),
+        ],
+        'Feather & Flame': [
+            ('Downpour', 'Downpour Drenches the World', ()),
+            ('Finder', 'Finder of Paths Unseen', ()),
+            ('Wildfire', 'Heart of the Wildfire', ('Transforming',)),
+            ('Serpent', 'Serpent Slumbering Beneath the Island', ('Locus',)),
+        ],
+        'Horizons of Spirit Island': [
+            ('Teeth', 'Devouring Teeth Lurk Underfoot', ()),
+            ('Eyes', 'Eyes Watch from the Trees', ()),
+            ('Mud', 'Fathomless Mud of the Swamp', ()),
+            ('Heat', 'Rising Heat of Stone and Sand', ()),
+            ('Whirlwind', 'Sun-Bright Whirlwind', ()),
+        ],
+        'Nature Incarnate': [
+            ('Breath', 'Breath of Darkness Down Your Spine', ()),
+            ('Earthquakes', 'Dances Up Earthquakes', ()),
+            ('Behemoth', 'Ember-Eyed Behemoth', ()),
+            ('Vigil', 'Hearth-Vigil', ()),
+            ('Gaze', 'Relentless Gaze of the Sun', ()),
+            ('Roots', 'Towering Roots of the Jungle', ()),
+            ('Voice', 'Wandering Voice Keens Delirium', ()),
+            ('Waters', 'Wounded Waters Bleeding', ()),
+        ],
+        'Apocrypha': [
+            ('Covets', 'Covets Gleaming Shards of Earth [Apocrypha]', ()),
+            ('Rot', 'Spreading Rot Renews the Earth [Apocrypha]', ('Round Down',)),
+        ],
+        'Exploratory Testing': [
+            # If this changes to become an aspect of Bringer of Dreams and Nightmares,
+            # the template will need a slight change, because base Bringer should not be shown.
+            # That can be dealt with by a conditional in the template
+            # (don't show the base spirit if the category is Exploratory Testing)
+            ('Exploratory Bringer', 'Bringer of Dreams and Nightmares [Exploratory]', ()),
+        ],
+    }
+    for spirits in spirits_by_expansion.values():
+        spirits.sort()
+    spirits_present = [spirit for (expansion, spirits) in spirits_by_expansion.items() for (spirit, _, _) in spirits]
     spirits = [s.name for s in Spirit.objects.order_by('name').all()]
-    spirits.append('Lightning - Immense')
-    spirits.append('Lightning - Pandemonium')
-    spirits.append('Lightning - Wind')
-    spirits.append('River - Sunshine')
-    spirits.append('River - Travel')
-    spirits.append('River - Haven')
-    spirits.append('Earth - Might')
-    spirits.append('Earth - Resilence')
-    spirits.append('Earth - Nourishing')
-    spirits.append('Shadows - Amorphous')
-    spirits.append('Shadows - DarkFire')
-    spirits.append('Shadows - Foreboding')
-    spirits.append('Shadows - Madness')
-    spirits.append('Shadows - Reach')
-    spirits.append('Fangs - Encircle')
-    spirits.append('Bringer - Enticing')
-    spirits.append('Shifting - Intensify')
-    spirits.append('Shifting - Mentor')
-    spirits.append('Lure - Lair')
-    spirits.append('Green - Regrowth')
-    spirits.append('Lightning - Sparking')
-    spirits.append('Keeper - Spreading Hostility')
-    spirits.append('Mist - Stranded')
-    spirits.append('Thunderspeaker - Tactician')
-    spirits.append('Green - Tangles')
-    spirits.append('Wildfire - Transforming')
-    spirits.append('Fangs - Unconstrained')
-    spirits.append('Bringer - Violence')
-    spirits.append('Thunderspeaker - Warrior')
-    spirits.append('Ocean - Deeps')
-    spirits.append('Serpent - Locus')
-    spirits.append('Rot - Round Down')
-    spirits.sort()
+
+    # These messages are useful while in development;
+    # we expect that they do not get printed in production.
+    missing_spirits = set(spirits) - set(spirits_present)
+    if missing_spirits:
+        print(f"Warning: missing spirits {missing_spirits}")
+    unknown_spirits = set(spirits_present) - set(spirits)
+    if unknown_spirits:
+        print(f"Warning: unknown spirits {unknown_spirits}")
+
     logs = reversed(game.gamelog_set.order_by('-date').all()[:30])
-    return render(request, 'game.html', { 'game': game, 'spirits': spirits, 'logs': logs })
+    return render(request, 'game.html', { 'game': game, 'spirits_by_expansion': spirits_by_expansion, 'logs': logs })
 
 def draw_card(request, game_id, type):
     game = get_object_or_404(Game, pk=game_id)


### PR DESCRIPTION
closes https://github.com/nathanj/spirit-island-pbp/issues/60 if the Apocrypha category and Exploratory Testing category are sufficiently clear that these spirits are set apart from the rest.

---

It can be a little cryptic to only show one word of the name, and for
some spirits it's not clear which word I should look for

For example:

* Fractured Days Split the Sky: Fractured or Days?
* Shifting Memory of Ages: Shifting or Memory?
* Shroud of Silent Mist: Mist or Shroud?

By showing the full name, there is no longer any question.
Disadvantage: the dropdown does get quite wide.