### PR TITLE
GamePlayer#thresholds: check Dances Up Earthquakes' played cards

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -417,6 +417,18 @@ class GamePlayer(models.Model):
                 name += ' - Renew'
             elif self.healing.all().contains(Card.objects.get(name='Waters Taste of Ruin')):
                 name += ' - Ruin'
+        if name == 'Earthquakes':
+            # Show additional threshold indicators for whether enough cards are in play.
+            #
+            # We are keeping these separate from the elements threshold indicators to avoid surprise:
+            # Most other threshold indicators are only counting elements,
+            # so it would be too surprising if the ones for Earth Shudders, Buildings Fall also counted card plays.
+            #
+            # Therefore, it seems the least-surprising thing is just to show separate indicators.
+            # They are placed right over the icon for card plays.
+            cards_in_play = self.play.count() + self.impending_with_energy.filter(gameplayerimpendingwithenergy__in_play=True).count()
+            for (y, n) in ((475, 3), (525, 5), (580, 7)):
+                thresholds.append(Threshold(737, y, cards_in_play >= n))
         if name in spirit_thresholds:
             for t in spirit_thresholds[name]:
                 thresholds.append(Threshold(t[0], t[1], check_elements(elements, t[2], equiv_elements)))


### PR DESCRIPTION
Closes https://github.com/nathanj/spirit-island-pbp/issues/51

Priority here is to be clear to the players. I would think that combining the elements and card plays into one checkmark/X indicator is too confusing. So what about separate indicators for each?

![esbf](https://github.com/user-attachments/assets/cf5e2493-65a8-4644-a7e0-28c202a05efa)

Note that I've checked two other digital implementations of Dances Up Earthquakes' spirit panel, and neither of them show a checkmark for card plays (both of them show one checkmark only, for the elements only) so being the only implementation that shows one for card plays carries additional risk of being confusing via unfamiliarity.