### PR TITLE
allow players to undo gaining cards

### DIFF
--- a/island/urls.py
+++ b/island/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path('game/<int:player_id>/rot/gain', views.gain_rot, name='gain_rot'),
     path('game/<int:player_id>/rot/convert', views.convert_rot, name='convert_rot'),
     path('game/<int:player_id>/presence/<int:left>/<int:top>', views.toggle_presence, name='toggle_presence'),
+    path('game/<int:player_id>/undo-gain-card', views.undo_gain_card, name='undo_gain_card'),
     path('game/<int:player_id>/ready', views.ready, name='ready'),
     path('game/<int:player_id>/element/<str:element>/add', views.add_element, name='add_element'),
     path('game/<int:player_id>/element/<str:element>/remove', views.remove_element, name='remove_element'),

--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -131,6 +131,7 @@
       </div>
     </div>
   </ul>
+  <button class="btn" hx-get="{% url 'undo_gain_card' player.id %}" hx-confirm="Are you sure?">Oops! Undo gain card</button>
   {% else %}
   <p>Gain Minor ({{ player.game.minor_deck.all | length }} in deck): <button class="btn" hx-get="{% url 'gain_power' player.id 'minor' '4' %}">4 Cards</button> <button class="btn" hx-get="{% url 'gain_power' player.id 'minor' '6' %}">6 Cards</button> <button class="btn" hx-get="{% url 'take_power' player.id 'minor' %}">1 Card</button>
   <p>Gain Major ({{ player.game.major_deck.all | length }} in deck): <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '4' %}">4 Cards</button> <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '2' %}">2 Cards</button> <button class="btn" hx-get="{% url 'take_power' player.id 'major' %}">1 Card</button>

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -605,6 +605,30 @@ def choose_card(request, player_id, card_id):
     compute_card_thresholds(player)
     return with_log_trigger(render(request, 'player.html', {'player': player}))
 
+def undo_gain_card(request, player_id):
+    player = get_object_or_404(GamePlayer, pk=player_id)
+    game = player.game
+
+    to_remove = []
+    for sel in player.selection.all():
+        if sel.type == Card.MINOR:
+            game.minor_deck.add(sel)
+            # we don't remove from player.selection immediately,
+            # as that would modify the selection we're iterating over.
+            to_remove.append(sel)
+        elif sel.type == Card.MAJOR:
+            game.major_deck.add(sel)
+            to_remove.append(sel)
+        elif sel.name in ("Serene Waters", "Waters Renew", "Roiling Waters", "Waters Taste of Ruin"):
+            to_remove.append(sel)
+        # If it's not any of these types, we'll leave it in selection, as something's gone wrong.
+
+    for rem in to_remove:
+        player.selection.remove(rem)
+
+    compute_card_thresholds(player)
+    return with_log_trigger(render(request, 'player.html', {'player': player}))
+
 def choose_healing_card(request, player, card):
     player.healing.add(card)
     player.selection.clear()


### PR DESCRIPTION
Sometimes players accidentally hit the button and then need an admin's help to reshuffle the cards back in the deck.

This change will let them do it themselves.

It is assumed that players will only use this when they genuinely made a mistake rather than to cheat on their card gains.

This doesn't help if someone accidentally hit the Take 1 button though, since then the card goes right to their hand instead of to the selection. Something else will be needed for that case.