### PR TITLE
api: show complete information about a game

### DIFF
--- a/pbf/api.py
+++ b/pbf/api.py
@@ -1,16 +1,66 @@
 from django.shortcuts import get_object_or_404
 from typing import List
 from ninja import NinjaAPI
-from ninja import ModelSchema
+from ninja import Field, ModelSchema
 import os
-from .models import Game, GameLog
+from .models import Card, Game, GameLog, GamePlayer, GamePlayerImpendingWithEnergy, Presence, Spirit
 
 api = NinjaAPI()
+
+class SpiritSchema(ModelSchema):
+    class Config:
+        model = Spirit
+        model_fields = ['id', 'name']
+
+class CardSchema(ModelSchema):
+    class Config:
+        model = Card
+        model_fields = ['id', 'name']
+
+class ImpendingSchema(ModelSchema):
+    card: CardSchema = None
+    class Config:
+        model = GamePlayerImpendingWithEnergy
+        model_fields = ['energy', 'in_play']
+
+class PresenceSchema(ModelSchema):
+    class Config:
+        model = Presence
+        model_fields = ['opacity', 'energy', 'elements']
+
+class GamePlayerSchema(ModelSchema):
+    spirit: SpiritSchema = None
+    hand: List[CardSchema] = []
+    discard: List[CardSchema] = []
+    play: List[CardSchema] = []
+    selection: List[CardSchema] = []
+    days: List[CardSchema] = []
+    healing: List[CardSchema] = []
+    impending: List[ImpendingSchema] = Field([], alias="gameplayerimpendingwithenergy_set")
+    presence: List[PresenceSchema] = Field([], alias="presence_set")
+    class Config:
+        model = GamePlayer
+        model_fields = [
+                'name', 'ready', 'paid_this_turn', 'gained_this_turn', 'energy', 'color', 'aspect',
+                'temporary_sun', 'temporary_moon', 'temporary_fire', 'temporary_air', 'temporary_water', 'temporary_earth', 'temporary_plant', 'temporary_animal',
+                'permanent_sun', 'permanent_moon', 'permanent_fire', 'permanent_air', 'permanent_water', 'permanent_earth', 'permanent_plant', 'permanent_animal',
+                'spirit_specific_resource', 'spirit_specific_per_turn_flags',
+                ]
 
 class GameSchema(ModelSchema):
     class Config:
         model = Game
         model_fields = ['id', 'turn', 'name', 'discord_channel']
+
+class GameDetailSchema(ModelSchema):
+    players: List[GamePlayerSchema] = Field([], alias="gameplayer_set")
+    minor_deck: List[CardSchema] = []
+    major_deck: List[CardSchema] = []
+    discard_pile: List[CardSchema] = []
+    class Config:
+        model = Game
+        # we've not exported the screenshots, because it's not obvious how we would do it.
+        model_fields = ['id', 'name', 'discord_channel', 'scenario']
 
 class GameLogSchema(ModelSchema):
     class Config:
@@ -46,7 +96,7 @@ def game_link(request, game_id, channel_id):
 def game(request):
     return Game.objects.all()
 
-@api.get("/game/{game_id}", response=GameSchema)
+@api.get("/game/{game_id}", response=GameDetailSchema)
 def game(request, game_id):
     return get_object_or_404(Game, pk=game_id)
 

--- a/pbf/api.py
+++ b/pbf/api.py
@@ -50,7 +50,7 @@ class GamePlayerSchema(ModelSchema):
 class GameSchema(ModelSchema):
     class Config:
         model = Game
-        model_fields = ['id', 'turn', 'name', 'discord_channel']
+        model_fields = ['id', 'name', 'discord_channel', 'scenario']
 
 class GameDetailSchema(ModelSchema):
     players: List[GamePlayerSchema] = Field([], alias="gameplayer_set")


### PR DESCRIPTION
my intent is to have the GET /api/game/{uuid} endpoint give the complete information about the game state, such that (if it should ever be necessary) a game can fully be reconstructed by using the data from that endpoint.

(It won't have the images, but I leave that to individual games' hosts)