### PR TITLE
show count of elements in minor/major power decks

### DIFF
--- a/pbf/templates/power_deck.html
+++ b/pbf/templates/power_deck.html
@@ -2,6 +2,14 @@
 
 <p>
 <h4>{{ name }} deck ({{ cards | length }} cards):</h4>
+
+{% for elt, count in elements %}
+  {% with "pbf/element-"|add:elt|add:".png" as elt_img %}
+    <img src="{% static elt_img %}" alt="{{elt}}" style="width: 1.8em; height: 1.8em" />
+  {% endwith %}
+  <span style="font-size: 2em;">{{ count }}</span>
+{% endfor %}
+
 <ul>
   <div class="container-fluid">
     <div class="row">

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -544,13 +544,17 @@ def gain_power(request, player_id, type, num):
     compute_card_thresholds(player)
     return with_log_trigger(render(request, 'player.html', {'player': player}))
 
+def deck_elements(deck):
+    cards = deck.all()
+    return [(elt.name.lower(), sum(elt.name in card.elements for card in cards)) for elt in Elements]
+
 def minor_deck(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
-    return render(request, 'power_deck.html', {'name': 'Minor', 'cards': game.minor_deck.all()})
+    return render(request, 'power_deck.html', {'name': 'Minor', 'cards': game.minor_deck.all(), 'elements': deck_elements(game.minor_deck)})
 
 def major_deck(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
-    return render(request, 'power_deck.html', {'name': 'Major', 'cards': game.major_deck.all()})
+    return render(request, 'power_deck.html', {'name': 'Major', 'cards': game.major_deck.all(), 'elements': deck_elements(game.major_deck)})
 
 def discard_pile(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)


### PR DESCRIPTION
This helps calculate deck odds for simple queries like "how likely am I to find a card with this one particular element?"

It can't help with the more complicated ones like "how many of those also cost 0 energy?" or "which cards have this pair of elements"; such a thing would require a more fully-fledged filtering interface.