### PR TITLE
Log message when forgetting a card

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -779,6 +779,8 @@ def forget_card(request, player_id, card_id):
         except:
             pass
 
+    add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} forgets {card.name}')
+
     compute_card_thresholds(player)
     return with_log_trigger(render(request, 'player.html', {'player': player}))
 


### PR DESCRIPTION
We should now log a message when a card is forgotten, similar to those logged when gaining a card: 

![image](https://github.com/user-attachments/assets/c6ddb828-186d-4d0d-8458-f524f7755f9e)

Note: I haven't set up bots yet so I can't confirm for sure if it flows through to Discord as well.