### PR TITLE
Remove Boon of Vigor from Sunshine River

### DIFF
--- a/pbf/tests.py
+++ b/pbf/tests.py
@@ -22,6 +22,7 @@ class TestSetupEnergyAndBaseGain(TestCase):
 
     def test_aspect_modifying_setup_energy(self):
         Spirit(name="River").save()
+        Card(name="Boon of Vigor", cost=0, type=2, speed=1).save()
         s = self.assert_spirit("River - Sunshine", per_turn=1, setup=1)
 
     def test_aspect_modifying_nothing(self):

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -279,6 +279,7 @@ spirit_remove_cards = {
     'ViolenceBringer': ['Dreams of the Dahan'],
     'WarriorThunderspeaker': ['Manifestation of Power and Glory'],
     'LocusSerpent': ['Elemental Aegis'],
+    'SunshineRiver': ['Boon of Vigor'],
     }
 
 def add_player(request, game_id):


### PR DESCRIPTION
Removes Boon of Vigor from Sunshine River's starting hand per the aspect's instructions.

Closes #65 