### PR TITLE
Card: Don't include the speed column if seeding the DB

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -1,6 +1,7 @@
 import uuid
 from enum import Enum
 from collections import Counter, defaultdict
+import sys
 
 from django.db import models
 
@@ -91,7 +92,14 @@ class Card(models.Model):
 
     FAST = 1
     SLOW = 2
-    speed = models.IntegerField(choices=[(0, 'Unknown'), (FAST, 'Fast'), (SLOW, 'Slow')])
+
+    if 'seeddb' in sys.argv and any('manage.py' in s for s in sys.argv):
+        # Don't include the speed field during seeding,
+        # because seeding is run on a DB that doesn't have the speed field.
+        # intended to be a temporary solution to https://github.com/nathanj/spirit-island-pbp/issues/90
+        pass
+    else:
+        speed = models.IntegerField(choices=[(0, 'Unknown'), (FAST, 'Fast'), (SLOW, 'Slow')])
 
     def __str__(self):
         return self.name


### PR DESCRIPTION
while this *is* a solution to
https://github.com/nathanj/spirit-island-pbp/issues/90 (the issue where seeddb can't use the Card model because it expects to find the speed column), it is intended to be a temporary one.

we would want to apply this temporary solution if someone wants to get started on the project before we finish the other proposed solution (that being to change from seeding to a migration)