### PR TITLE
GamePlayer: use elements to give Dark Fire and Intensify their permanent moon

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -387,7 +387,12 @@ class GamePlayer(models.Model):
     def plant(self): return self.elements[Elements.Plant]
     def animal(self): return self.elements[Elements.Animal]
 
-    def init_permanent_elements(self):
+    # Any code that creates a GamePlayer is expected to (manually) call this function once after creating it,
+    # (currently add_player in views)
+    # so it is suitable for any one-time setup.
+    # why not override __init__? Django docs indicate doing so is *not* preferred:
+    # https://docs.djangoproject.com/en/5.1/ref/models/instances/
+    def init_spirit(self):
         if self.spirit.name == "Shifting":
             for e in (Elements.Moon, Elements.Air, Elements.Earth):
                 # Prepare one of each.

--- a/pbf/models.py
+++ b/pbf/models.py
@@ -360,6 +360,10 @@ class GamePlayer(models.Model):
         counter[Elements.Earth] += self.temporary_earth + self.permanent_earth
         counter[Elements.Plant] += self.temporary_plant + self.permanent_plant
         counter[Elements.Animal] += self.temporary_animal + self.permanent_animal
+
+        if self.aspect == 'DarkFire':
+            counter[Elements.Moon] += 1
+
         for card in self.play.all():
             counter += card.get_elements()
         if self.spirit.name == 'Earthquakes':
@@ -384,9 +388,7 @@ class GamePlayer(models.Model):
     def animal(self): return self.elements[Elements.Animal]
 
     def init_permanent_elements(self):
-        if self.aspect == 'DarkFire':
-            self.permanent_moon += 1
-        elif self.spirit.name == "Shifting":
+        if self.spirit.name == "Shifting":
             for e in (Elements.Moon, Elements.Air, Elements.Earth):
                 # Prepare one of each.
                 self.spirit_specific_resource += 1 << (ELEMENT_WIDTH * (e.value - 1))

--- a/pbf/models.py
+++ b/pbf/models.py
@@ -361,7 +361,7 @@ class GamePlayer(models.Model):
         counter[Elements.Plant] += self.temporary_plant + self.permanent_plant
         counter[Elements.Animal] += self.temporary_animal + self.permanent_animal
 
-        if self.aspect == 'DarkFire':
+        if self.aspect in ('DarkFire', 'Intensify'):
             counter[Elements.Moon] += 1
 
         for card in self.play.all():

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -302,7 +302,7 @@ def add_player(request, game_id):
     # as noted above in the comment of spirit_base_energy_per_turn,
     # only spirit name (and not aspect) is considered in energy gain per turn.
     gp = GamePlayer(game=game, name=name, spirit=spirit, color=color, aspect=aspect, energy=setup_energy, starting_energy=spirit_base_energy_per_turn[spirit.name])
-    gp.init_permanent_elements()
+    gp.init_spirit()
     gp.save()
     try:
         for presence in spirit_presence[spirit.name]:


### PR DESCRIPTION
Previous behaviour:

* Dark Fire was using permanent elements, which I didn't like because a player may decrement it.
* Intensify didn't have its permanent element at all

Intentionally no migration. Just having everyone currently playing them adjust manually.