### PR TITLE
island/settings: Make EXTRA_ALLOWED_HOSTS optional

### DIFF
--- a/island/settings.py
+++ b/island/settings.py
@@ -31,9 +31,8 @@ DEBUG = os.environ.get('DEBUG', '') == 'yes'
 
 ALLOWED_HOSTS = ['localhost', 'si.bitcrafter.net']
 
-EXTRA_ALLOWED_HOSTS = os.environ['EXTRA_ALLOWED_HOSTS']
-if EXTRA_ALLOWED_HOSTS:
-    ALLOWED_HOSTS = ALLOWED_HOSTS + [EXTRA_ALLOWED_HOSTS]
+if 'EXTRA_ALLOWED_HOSTS' in os.environ:
+    ALLOWED_HOSTS = ALLOWED_HOSTS + [os.environ['EXTRA_ALLOWED_HOSTS']]
 
 CSRF_TRUSTED_ORIGINS = ['https://si.bitcrafter.net']
 


### PR DESCRIPTION
otherwise, the commands in the README will error with a KeyError on EXTRA_ALLOWED_HOSTS