### PR TITLE
don't crash if players have the same colour

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -139,9 +139,8 @@ class Game(models.Model):
 
     def available_colors(self):
         colors = ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'purple', 'pink', 'brown', 'white']
-        for player in self.gameplayer_set.all():
-            colors.remove(player.color)
-        return colors
+        player_colors = set(self.gameplayer_set.values_list('color', flat=True))
+        return [c for c in colors if c not in player_colors]
 
 
 colors_to_circle_color_map = {


### PR DESCRIPTION
removing available colours using a set (rather than a `for` loop) isn't just for flashier code; it actually has a subtle behaviour change for duplicate colours.

Before this change, using the admin interface to set two players to the same colour causes `available_colors` to crash, as `remove` does when removing a nonexistent element. This means the game cannot be loaded.

However, it's my opinion that if an admin *really* wants to do this, they should be allowed to do so (at their own risk), without causing the game to be unloadable. It's discouraged because it may be confusing to the players, but a more graceful response than crashing is called for if it so happens.

We still will not allow duplicate colours to be assigned in the UI, because it's confusing and unlikely to desired most of the time. If an admin really wants it, making them go through the effort of manually assigning it reinforces that it should be done with careful thought.