### PR TITLE
add scroll workaround (change all buttons to a)

### DIFF
--- a/island/urls.py
+++ b/island/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('game/<str:game_id>/change_game_name', views.change_game_name, name='change_game_name'),
     path('game/<str:game_id>/change_scenario', views.change_scenario, name='change_scenario'),
     path('game/<str:game_id>/edit_players', views.edit_players, name='edit_players'),
+    path('game/<str:game_id>/change_button_or_a_mode', views.change_button_or_a_mode, name='change_button_or_a_mode'),
     path('game/<int:player_id>/gain/<str:type>/<int:num>', views.gain_power, name='gain_power'),
     path('game/<int:player_id>/gain_healing', views.gain_healing, name='gain_healing'),
     path('game/<int:player_id>/take/<str:type>/<int:num>', views.take_powers, name='take_powers'),

--- a/pbf/templates/discard_pile.html
+++ b/pbf/templates/discard_pile.html
@@ -11,12 +11,12 @@
 	  <div class="card p-0 m-15">
 	    <img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	    <div class="text-center pb-5">
-	      <button class="btn" hx-get="{% url 'choose_from_discard' player.id card.id %}">Take</button>
+	      <{{button_or_a}} class="btn" hx-get="{% url 'choose_from_discard' player.id card.id %}">Take</{{button_or_a}}>
 	      {% if player.spirit.name == 'Fractured' %}
-	      <button class="btn" hx-get="{% url 'send_days' player.id card.id %}">Days</button>
+	      <{{button_or_a}} class="btn" hx-get="{% url 'send_days' player.id card.id %}">Days</{{button_or_a}}>
 	      {% endif %}
 	      {% if card.can_return_to_deck %}
-	      <button class="btn" hx-get="{% url 'return_to_deck' player.id card.id %}" hx-confirm="This will shuffle the card back into its power card deck. Are you sure?">Deck</button>
+	      <{{button_or_a}} class="btn" hx-get="{% url 'return_to_deck' player.id card.id %}" hx-confirm="This will shuffle the card back into its power card deck. Are you sure?">Deck</{{button_or_a}}>
 	      {% endif %}
 	    </div>
 	  </div>

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -65,6 +65,18 @@
     <div class="col-lg-3">
       <div class="content">
 	<button class="btn" type="button" onclick="halfmoon.toggleDarkMode()">Dark Mode</button>
+	<form method="post" action="{% url 'change_button_or_a_mode' game.id %}">
+	  {% csrf_token %}
+	  <button type="submit" class="btn">Scroll Workaround</button>
+	</form>
+
+  <abbr title="For some browsers/OSes, clicking the buttons to manipulate power cards (play, unplay, discard, etc.) causes the page to scroll/jump around. You can try hitting the Scroll Workaround button to change the current mode to 'Fixing scroll jumps' (instead of 'default') to work around this issue. It may cause some slightly annoying side effects (browsers will attempt to highlight the button text), so it's a temporary workaround until we can find a better solution.">Current mode:
+  {% if button_or_a == "button" %}
+  Default (recommended)
+  {% else %}
+  Fixing scroll jumps
+  {% endif %}
+  </abbr>
       </div>
       {% include "logs.html" %}
     </div>

--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -91,14 +91,14 @@
   </div>
 
   {% if player.ready %}
-  <button class="btn"
+  <{{button_or_a}} class="btn"
 	  style="background-color: #8a8;"
-	  hx-get="{% url 'discard_all' player.id %}">Ready! Click to Discard All Played and Unready</button>
+	  hx-get="{% url 'discard_all' player.id %}">Ready! Click to Discard All Played and Unready</{{button_or_a}}>
   {% else %}
-  <button class="btn"
+  <{{button_or_a}} class="btn"
 	  hx-get="{% url 'ready' player.id %}"
 	  style="background-color: #a88;"
-	  >Not Ready</button>
+	  >Not Ready</{{button_or_a}}>
   {% endif %}
 
   <br/>
@@ -127,9 +127,9 @@
 		<img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	      </div>
 	      <div class="text-center pb-5">
-		<button class="btn" hx-get="{% url 'choose_card' player.id card.id %}">Choose</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'choose_card' player.id card.id %}">Choose</{{button_or_a}}>
 		{% if player.spirit.name == 'Fractured' %}
-		<button class="btn" hx-get="{% url 'send_days' player.id card.id %}">Send to Days</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'send_days' player.id card.id %}">Send to Days</{{button_or_a}}>
 		{% endif %}
 	      </div>
 	    </div>
@@ -139,39 +139,39 @@
       </div>
     </div>
   </ul>
-  <button class="btn" hx-get="{% url 'undo_gain_card' player.id %}" hx-confirm="Are you sure?">Oops! Undo gain card</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'undo_gain_card' player.id %}" hx-confirm="Are you sure?">Oops! Undo gain card</{{button_or_a}}>
   {% else %}
   <p>Gain Minor ({{ player.game.minor_deck.count }} in deck):
   {% if player.aspect == 'Mentor' %}
-  <button class="btn" hx-get="{% url 'take_powers' player.id 'minor' '2' %}">2 Cards (keep 2)</button>
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'minor' '4' %}" hx-confirm="Confirm you want to look at 4 minor power cards and keep 3 (Starlight Seeks Its Form used Boon of Reimagining on you)?">4 Cards (keep 3)</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'take_powers' player.id 'minor' '2' %}">2 Cards (keep 2)</{{button_or_a}}>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'minor' '4' %}" hx-confirm="Confirm you want to look at 4 minor power cards and keep 3 (Starlight Seeks Its Form used Boon of Reimagining on you)?">4 Cards (keep 3)</{{button_or_a}}>
   {% else %}
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'minor' '4' %}">4 Cards</button>
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'minor' '6' %}">6 Cards</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'minor' '4' %}">4 Cards</{{button_or_a}}>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'minor' '6' %}">6 Cards</{{button_or_a}}>
   {% endif %}
-  <button class="btn" hx-get="{% url 'take_powers' player.id 'minor' '1' %}">1 Card</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'take_powers' player.id 'minor' '1' %}">1 Card</{{button_or_a}}>
 
-  <button class="btn" hx-get="{% url 'minor_deck' player.game.id %}" hx-target="#Minor-deck" hx-swap="innerHTML">Show deck</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'minor_deck' player.game.id %}" hx-target="#Minor-deck" hx-swap="innerHTML">Show deck</{{button_or_a}}>
   <div id="Minor-deck"></div>
 
   <p>Gain Major ({{ player.game.major_deck.count }} in deck):
   {% if player.aspect == 'Mentor' %}
-  <button class="btn" hx-get="{% url 'take_powers' player.id 'major' '2' %}">2 Cards (keep 2)</button>
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '4' %}" hx-confirm="Confirm you want to look at 4 major power cards and keep 1 (event Visions Out of Time)?">4 Cards</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'take_powers' player.id 'major' '2' %}">2 Cards (keep 2)</{{button_or_a}}>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'major' '4' %}" hx-confirm="Confirm you want to look at 4 major power cards and keep 1 (event Visions Out of Time)?">4 Cards</{{button_or_a}}>
   {% else %}
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '4' %}">4 Cards</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'major' '4' %}">4 Cards</{{button_or_a}}>
   {% if player.spirit.name == 'Covets' %}
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '6' %}">6 Cards</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'major' '6' %}">6 Cards</{{button_or_a}}>
   {% endif %}
-  <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '2' %}">2 Cards</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'gain_power' player.id 'major' '2' %}">2 Cards</{{button_or_a}}>
   {% endif %}
-  <button class="btn" hx-get="{% url 'take_powers' player.id 'major' '1' %}">1 Card</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'take_powers' player.id 'major' '1' %}">1 Card</{{button_or_a}}>
 
-  <button class="btn" hx-get="{% url 'major_deck' player.game.id %}" hx-target="#Major-deck" hx-swap="innerHTML">Show deck</button>
+  <{{button_or_a}} class="btn" hx-get="{% url 'major_deck' player.game.id %}" hx-target="#Major-deck" hx-swap="innerHTML">Show deck</{{button_or_a}}>
   <div id="Major-deck"></div>
 
   {% if player.spirit.name == 'Waters' %}
-  <p>Gain Healing Card: <button class="btn" hx-get="{% url 'gain_healing' player.id %}">Gain Healing Card</button>
+  <p>Gain Healing Card: <{{button_or_a}} class="btn" hx-get="{% url 'gain_healing' player.id %}">Gain Healing Card</{{button_or_a}}>
   {% endif %}
   {% endif %}
 
@@ -189,7 +189,7 @@
         {% endfor %}
       </div>
     </div>
-    <button class="btn" onClick="document.getElementById('taken_cards').remove();">OK (dismiss)</button>
+    <{{button_or_a}} class="btn" onClick="document.getElementById('taken_cards').remove();">OK (dismiss)</{{button_or_a}}>
   </div>
   {% endif %}
 
@@ -215,9 +215,9 @@
 		<img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	      </div>
 	      <div class="text-center pb-5">
-		<button class="btn" hx-get="{% url 'unplay_card' player.id card.id %}">Unplay</button>
-		<button class="btn" hx-get="{% url 'discard_card' player.id card.id %}">Discard</button>
-		<button class="btn" hx-get="{% url 'forget_card' player.id card.id %}" hx-confirm="Are you sure?">Forget</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'unplay_card' player.id card.id %}">Unplay</{{button_or_a}}>
+		<{{button_or_a}} class="btn" hx-get="{% url 'discard_card' player.id card.id %}">Discard</{{button_or_a}}>
+		<{{button_or_a}} class="btn" hx-get="{% url 'forget_card' player.id card.id %}" hx-confirm="Are you sure?">Forget</{{button_or_a}}>
 	      </div>
 	    </div>
 	  </div>
@@ -240,12 +240,12 @@
 		<img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	      </div>
 	      <div class="text-center pb-5">
-		<button class="btn" hx-get="{% url 'play_card' player.id card.id %}">Play</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'play_card' player.id card.id %}">Play</{{button_or_a}}>
 		{% if player.spirit.name == 'Earthquakes' %}
-		<button class="btn" hx-get="{% url 'impend_card' player.id card.id %}">Impend</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'impend_card' player.id card.id %}">Impend</{{button_or_a}}>
 		{% endif %}
-		<button class="btn" hx-get="{% url 'discard_card' player.id card.id %}">Discard</button>
-		<button class="btn" hx-get="{% url 'forget_card' player.id card.id %}" hx-confirm="Are you sure?">Forget</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'discard_card' player.id card.id %}">Discard</{{button_or_a}}>
+		<{{button_or_a}} class="btn" hx-get="{% url 'forget_card' player.id card.id %}" hx-confirm="Are you sure?">Forget</{{button_or_a}}>
 	      </div>
 	    </div>
 	  </div>
@@ -262,7 +262,7 @@
     {% if player.spirit_specific_incremented_this_turn %}
       Gained all this turn!
     {% else %}
-      <button class="btn" hx-get="{% url 'gain_energy_on_impending' player.id %}">+{{player.impending_energy}} to all cards made impending on previous turns</button>
+      <{{button_or_a}} class="btn" hx-get="{% url 'gain_energy_on_impending' player.id %}">+{{player.impending_energy}} to all cards made impending on previous turns</{{button_or_a}}>
     {% endif %}
 
   <ul>
@@ -281,21 +281,21 @@
 		<img src="{% static i.card.url %}" class="img-fluid rounded-top" alt="{{i.card.name}}">
 	      </div>
 	      <div class="text-center pb-5">
-		    <button class="btn" hx-get="{% url 'add_energy_to_impending' player.id i.card.id %}" {% if i.in_play or i.energy >= i.cost_with_scenario %}disabled{% endif %}>+1</button>
+		    <{{button_or_a}} class="btn" hx-get="{% url 'add_energy_to_impending' player.id i.card.id %}" {% if i.in_play or i.energy >= i.cost_with_scenario %}disabled{% endif %}>+1</{{button_or_a}}>
 			{% if i.energy >= i.cost_with_scenario %}
 				{% if i.in_play %}
-					<button class="btn" hx-get="{% url 'unplay_from_impending' player.id i.card.id %}">Unplay</button>
+					<{{button_or_a}} class="btn" hx-get="{% url 'unplay_from_impending' player.id i.card.id %}">Unplay</{{button_or_a}}>
 				{% else %}
-		   			<button class="btn" hx-get="{% url 'play_from_impending' player.id i.card.id %}">Play</button>
+		   			<{{button_or_a}} class="btn" hx-get="{% url 'play_from_impending' player.id i.card.id %}">Play</{{button_or_a}}>
 				{% endif %}
 			{% else %}
-				<button class="btn" disabled>{{ i.energy }} / {{ i.cost_with_scenario }}</button>
+				<{{button_or_a}} class="btn" disabled>{{ i.energy }} / {{ i.cost_with_scenario }}</{{button_or_a}}>
 			{% endif %}
-		    <button class="btn" hx-get="{% url 'remove_energy_from_impending' player.id i.card.id %}" {% if i.in_play or i.energy <= 0 %}disabled{% endif %}>-1</button>
+		    <{{button_or_a}} class="btn" hx-get="{% url 'remove_energy_from_impending' player.id i.card.id %}" {% if i.in_play or i.energy <= 0 %}disabled{% endif %}>-1</{{button_or_a}}>
 	      </div>
 	      <div class="text-center pb-5">
-		    <button class="btn" hx-get="{% url 'unimpend_card' player.id i.card.id %}">Unimpend</button>
-		    <button class="btn" hx-get="{% url 'forget_card' player.id i.card.id %}" hx-confirm="Are you sure?">Forget</button>
+		    <{{button_or_a}} class="btn" hx-get="{% url 'unimpend_card' player.id i.card.id %}">Unimpend</{{button_or_a}}>
+		    <{{button_or_a}} class="btn" hx-get="{% url 'forget_card' player.id i.card.id %}" hx-confirm="Are you sure?">Forget</{{button_or_a}}>
 	      </div>
 	    </div>
 	  </div>
@@ -311,7 +311,7 @@
   <h4>Discard:</h4>
   <ul>
     {% if player.discard.count > 0 %}
-    <button class="btn" hx-get="{% url 'reclaim_all' player.id %}">Reclaim All</button>
+    <{{button_or_a}} class="btn" hx-get="{% url 'reclaim_all' player.id %}">Reclaim All</{{button_or_a}}>
     {% endif %}
 
 
@@ -323,8 +323,8 @@
 	    <div class="card p-0 m-5 m-md-10">
 	      <img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	      <div class="text-center pb-5">
-		<button class="btn" hx-get="{% url 'reclaim_card' player.id card.id %}">Reclaim</button>
-		<button class="btn" hx-get="{% url 'forget_card' player.id card.id %}" hx-confirm="Are you sure?">Forget</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'reclaim_card' player.id card.id %}">Reclaim</{{button_or_a}}>
+		<{{button_or_a}} class="btn" hx-get="{% url 'forget_card' player.id card.id %}" hx-confirm="Are you sure?">Forget</{{button_or_a}}>
 	      </div>
 	    </div>
 	  </div>
@@ -342,8 +342,8 @@
     <div class="container-fluid">
       <div class="row">
 	{% if player.days_ordered.count == 0 %}
-	<button class="btn" hx-get="{% url 'create_days' player.id 6 %}">Create Days (1 or 2 player game)</button><br>
-	<button class="btn" hx-get="{% url 'create_days' player.id 4 %}">Create Days (3+ player game)</button>
+	<{{button_or_a}} class="btn" hx-get="{% url 'create_days' player.id 6 %}">Create Days (1 or 2 player game)</{{button_or_a}}><br>
+	<{{button_or_a}} class="btn" hx-get="{% url 'create_days' player.id 4 %}">Create Days (3+ player game)</{{button_or_a}}>
 	{% else %}
 	{% for card in player.days_ordered.all %}
 	<div class="col-auto">
@@ -351,7 +351,7 @@
 	    <div class="card p-0 m-5 m-md-10">
 	      <img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	      <div class="text-center pb-5">
-		<button class="btn" hx-get="{% url 'choose_days' player.id card.id %}">Gain</button>
+		<{{button_or_a}} class="btn" hx-get="{% url 'choose_days' player.id card.id %}">Gain</{{button_or_a}}>
 	      </div>
 	    </div>
 	  </div>
@@ -367,7 +367,7 @@
   <div id="spirit-discard-deck-{{player.id}}"
        hx-target="#spirit-discard-deck-{{player.id}}"
        hx-swap="outerHTML">
-    <button class="btn" hx-get="{% url 'discard_pile' player.id %}">Show Power Discard Pile</button>
+    <{{button_or_a}} class="btn" hx-get="{% url 'discard_pile' player.id %}">Show Power Discard Pile</{{button_or_a}}>
   </div>
 
   <p>

--- a/pbf/templates/power_deck.html
+++ b/pbf/templates/power_deck.html
@@ -2,7 +2,7 @@
 
 <p>
 <h4>{{ name }} deck ({{ cards | length }} cards):</h4>
-<button class="btn" onClick="document.getElementById('{{name}}-deck').innerHTML='';">Close</button>
+<{{button_or_a}} class="btn" onClick="document.getElementById('{{name}}-deck').innerHTML='';">Close</{{button_or_a}}>
 <ul>
   <div class="container-fluid">
     <div class="row">
@@ -16,5 +16,5 @@
     </div>
   </div>
 </ul>
-<button class="btn" onClick="document.getElementById('{{name}}-deck').innerHTML='';">Close</button>
+<{{button_or_a}} class="btn" onClick="document.getElementById('{{name}}-deck').innerHTML='';">Close</{{button_or_a}}>
 </p>

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -454,7 +454,7 @@ def view_game(request, game_id, spirit_spec=None):
 
     tab_id = try_match_spirit(game, spirit_spec) or (game.gameplayer_set.first().id if game.gameplayer_set.exists() else None)
     logs = reversed(game.gamelog_set.order_by('-date').all()[:30])
-    return render(request, 'game.html', { 'game': game, 'logs': logs, 'tab_id': tab_id, 'spirit_spec': spirit_spec })
+    return render(request, 'game.html', { 'game': game, 'logs': logs, 'tab_id': tab_id, 'spirit_spec': spirit_spec, 'button_or_a': button_or_a(request) })
 
 def try_match_spirit(game, spirit_spec):
     if not spirit_spec:
@@ -577,7 +577,7 @@ def take_powers(request, player_id, type, num):
         add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} gains {num} {type} powers: {card_names}', images=",".join('./pbf/static' + card.url() for card in taken_cards))
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player, 'taken_cards': taken_cards}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'taken_cards': taken_cards, 'button_or_a': button_or_a(request)}))
 
 def gain_healing(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -591,7 +591,7 @@ def gain_healing(request, player_id):
     player.selection.set(selection)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def gain_power(request, player_id, type, num):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -605,19 +605,19 @@ def gain_power(request, player_id, type, num):
             images=images)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def minor_deck(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
-    return render(request, 'power_deck.html', {'name': 'Minor', 'cards': game.minor_deck.all()})
+    return render(request, 'power_deck.html', {'name': 'Minor', 'cards': game.minor_deck.all(), 'button_or_a': button_or_a(request)})
 
 def major_deck(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
-    return render(request, 'power_deck.html', {'name': 'Major', 'cards': game.major_deck.all()})
+    return render(request, 'power_deck.html', {'name': 'Major', 'cards': game.major_deck.all(), 'button_or_a': button_or_a(request)})
 
 def discard_pile(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
-    return render(request, 'discard_pile.html', { 'player': player })
+    return render(request, 'discard_pile.html', { 'player': player, 'button_or_a': button_or_a(request) })
 
 def return_to_deck(request, player_id, card_id):
     # this doesn't actually manipulate the player in any way,
@@ -635,7 +635,7 @@ def return_to_deck(request, player_id, card_id):
         raise ValueError(f"Can't return {card}")
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def choose_from_discard(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -646,7 +646,7 @@ def choose_from_discard(request, player_id, card_id):
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} takes {card.name} from the power discard pile')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def send_days(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -662,7 +662,7 @@ def send_days(request, player_id, card_id):
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} sends {card.name} to the Days That Never Were')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def choose_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -694,7 +694,7 @@ def choose_card(request, player_id, card_id):
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} gains {card.name}')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def undo_gain_card(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -718,7 +718,7 @@ def undo_gain_card(request, player_id):
         player.selection.remove(rem)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def choose_healing_card(request, player, card):
     if card.name.startswith('Waters'):
@@ -731,7 +731,7 @@ def choose_healing_card(request, player, card):
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} claims {card.name}')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def choose_days(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -742,7 +742,7 @@ def choose_days(request, player_id, card_id):
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} gains {card.name} from the Days That Never Were')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def create_days(request, player_id, num):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -756,7 +756,7 @@ def create_days(request, player_id, num):
             player.days.add(c)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def compute_card_thresholds(player):
     equiv_elements = player.equiv_elements()
@@ -799,7 +799,7 @@ def gain_energy_on_impending(request, player_id):
     player.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def impend_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -808,7 +808,7 @@ def impend_card(request, player_id, card_id):
     player.hand.remove(card)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def unimpend_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -817,7 +817,7 @@ def unimpend_card(request, player_id, card_id):
     player.hand.add(card)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def add_energy_to_impending(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -828,7 +828,7 @@ def add_energy_to_impending(request, player_id, card_id):
         impending_with_energy.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def remove_energy_from_impending(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -839,7 +839,7 @@ def remove_energy_from_impending(request, player_id, card_id):
         impending_with_energy.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def play_from_impending(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -850,7 +850,7 @@ def play_from_impending(request, player_id, card_id):
         impending_with_energy.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def unplay_from_impending(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -861,7 +861,7 @@ def unplay_from_impending(request, player_id, card_id):
         impending_with_energy.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def play_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -870,7 +870,7 @@ def play_card(request, player_id, card_id):
     player.hand.remove(card)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def unplay_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -879,7 +879,7 @@ def unplay_card(request, player_id, card_id):
     player.play.remove(card)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def forget_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -896,7 +896,7 @@ def forget_card(request, player_id, card_id):
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} forgets {card.name}')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 
 def reclaim_card(request, player_id, card_id):
@@ -906,7 +906,7 @@ def reclaim_card(request, player_id, card_id):
     player.discard.remove(card)
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def reclaim_all(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -916,7 +916,7 @@ def reclaim_all(request, player_id):
     player.discard.clear()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def discard_all(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -947,7 +947,7 @@ def discard_all(request, player_id):
     player.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def discard_card(request, player_id, card_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -965,7 +965,7 @@ def discard_card(request, player_id, card_id):
         pass
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def ready(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -987,7 +987,7 @@ def ready(request, player_id):
         add_log_msg(player.game, text=f'All spirits are ready!')
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def unready(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
@@ -1079,7 +1079,7 @@ def toggle_presence(request, player_id, left, top):
     presence.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def add_element(request, player_id, element):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -1094,7 +1094,7 @@ def add_element(request, player_id, element):
     player.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def remove_element(request, player_id, element):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -1109,7 +1109,7 @@ def remove_element(request, player_id, element):
     player.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def add_element_permanent(request, player_id, element):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -1124,7 +1124,7 @@ def add_element_permanent(request, player_id, element):
     player.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def remove_element_permanent(request, player_id, element):
     player = get_object_or_404(GamePlayer, pk=player_id)
@@ -1139,16 +1139,29 @@ def remove_element_permanent(request, player_id, element):
     player.save()
 
     compute_card_thresholds(player)
-    return with_log_trigger(render(request, 'player.html', {'player': player}))
+    return with_log_trigger(render(request, 'player.html', {'player': player, 'button_or_a': button_or_a(request)}))
 
 def tab(request, game_id, player_id):
     game = get_object_or_404(Game, pk=game_id)
     player = get_object_or_404(GamePlayer, pk=player_id)
     compute_card_thresholds(player)
-    return render(request, 'tabs.html', {'game': game, 'player': player})
+    return render(request, 'tabs.html', {'game': game, 'player': player, 'button_or_a': button_or_a(request)})
 
 def game_logs(request, game_id):
     game = get_object_or_404(Game, pk=game_id)
     logs = reversed(game.gamelog_set.order_by('-date').all()[:30])
     return render(request, 'logs.html', {'game': game, 'logs': logs})
 
+def button_or_a(request):
+    # The value of this function is used to construct an HTML tag,
+    # so we should only return known valid values, rather than arbitrary values from the cookie.
+    return 'a' if request.COOKIES.get('button_or_a') == 'a' else 'button'
+
+def change_button_or_a_mode(request, game_id):
+    # Game ID is only used to redirect back, not to manipulate the game.
+    resp = redirect(reverse('view_game', args=[game_id]))
+    if request.COOKIES.get('button_or_a') == 'a':
+        resp.delete_cookie('button_or_a')
+    else:
+        resp.set_cookie('button_or_a', 'a')
+    return resp


### PR DESCRIPTION
This sets a cookie that is used to choose whether to use `<button>` or `<a>`

Using `<a>` has some undesirable behaviour (the browser attempts to highlight the text when clicking it), but so far this is the only
reliable way that's been found to stop the UI from scrolling improperly on some browsers/platforms (Chrome-based browsers on Windows). So, we'll allow individual players to choose what works best for them.

https://github.com/nathanj/spirit-island-pbp/issues/131