### PR TITLE
choose_healing_card: add ability to change healing cards

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -680,6 +680,10 @@ def undo_gain_card(request, player_id):
     return with_log_trigger(render(request, 'player.html', {'player': player}))
 
 def choose_healing_card(request, player, card):
+    if card.name.startswith('Waters'):
+        player.healing.remove(player.healing.filter(name__startswith='Waters').first())
+    else:
+        player.healing.clear()
     player.healing.add(card)
     player.selection.clear()
 


### PR DESCRIPTION
Selecting either Roiling Waters or Serene Waters will clear all other healing cards.

Selecting either Waters Renew or Waters Taste of Ruin will clear the other.

Previously if you misclicked there was no way to undo your mistake.

In particular:

If you try to select both Roiling and Serene Waters, Serene Waters always appeared on top and covered Roiling Waters.

If you try to select both Waters Renew and Taste of Ruin, both innates would appear, but thresholds were for Waters Renew only; Waters Taste of Ruin was ignored and in fact kept shwing the indicators for Swirl and Spill.