### PR TITLE
add direct link to a spirit tab

### DIFF
--- a/island/urls.py
+++ b/island/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('screenshot/<str:filename>', views.view_screenshot, name='view_screenshot'),
     path('new', views.new_game, name='new_game'),
     path('game/<str:game_id>', views.view_game, name='view_game'),
+    path('game/<str:game_id>/spirit/<path:spirit_spec>', views.view_game, name='view_game'),
     path('game/<str:game_id>/logs', views.game_logs, name='game_logs'),
     path('game/<str:game_id>/unready', views.unready, name='unready'),
     path('game/<str:game_id>/time-passes', views.time_passes, name='time_passes'),

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -22,7 +22,7 @@
 	{% endif %}
 
 	{% if game.gameplayer_set.count > 0 %}
-	<div id="tabs" hx-get="{% url 'tab' game.id game.gameplayer_set.first.id %}" hx-trigger="load after:100ms" hx-target="#tabs" hx-swap="innerHTML"></div>
+	<div id="tabs" hx-get="{% url 'tab' game.id tab_id %}" hx-trigger="load after:100ms" hx-target="#tabs" hx-swap="innerHTML"></div>
 	{% endif %}
 
 	<hr />

--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -319,6 +319,15 @@
     <button class="btn" hx-get="{% url 'discard_pile' player.id %}">Show Power Discard Pile</button>
   </div>
 
+  <p>
+  Direct link to spirit:
+  <a href="{% if player.aspect %}{% url 'view_game' player.game.id player.aspect %}{% else %}{% url 'view_game' player.game.id player.spirit.name %}{% endif %}">by spirit</a>
+  {% if player.name %}
+  <a href="{% url 'view_game' player.game.id player.name %}">by player name</a>
+  {% endif %}
+  <a href="{% url 'view_game' player.game.id player.id %}">by ID</a>
+  </p>
+
   {% include "name.html" %}
   {% include "color.html" %}
 

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -334,7 +334,7 @@ def add_player(request, game_id):
 
     return redirect(reverse('view_game', args=[game.id]))
 
-def view_game(request, game_id):
+def view_game(request, game_id, spirit_spec=None):
     game = get_object_or_404(Game, pk=game_id)
     if request.method == 'POST':
         if 'screenshot' in request.FILES:
@@ -342,13 +342,13 @@ def view_game(request, game_id):
             if form.is_valid():
                 form.save()
                 add_log_msg(game, text=f'New screenshot uploaded.', images='.' + game.screenshot.url)
-                return redirect(reverse('view_game', args=[game.id]))
+                return redirect(reverse('view_game', args=[game.id, spirit_spec]))
         if 'screenshot2' in request.FILES:
             form = GameForm2(request.POST, request.FILES, instance=game)
             if form.is_valid():
                 form.save()
                 add_log_msg(game, text=f'New screenshot uploaded.', images='.' + game.screenshot2.url)
-                return redirect(reverse('view_game', args=[game.id]))
+                return redirect(reverse('view_game', args=[game.id, spirit_spec]))
 
     spirits_by_expansion = {
         # Short name, full name, aspects (if any)
@@ -434,8 +434,42 @@ def view_game(request, game_id):
     if unknown_spirits:
         print(f"Warning: unknown spirits {unknown_spirits}")
 
+    tab_id = try_match_spirit(game, spirit_spec) or (game.gameplayer_set.first().id if game.gameplayer_set.exists() else None)
     logs = reversed(game.gamelog_set.order_by('-date').all()[:30])
-    return render(request, 'game.html', { 'game': game, 'spirits_by_expansion': spirits_by_expansion, 'logs': logs })
+    return render(request, 'game.html', { 'game': game, 'spirits_by_expansion': spirits_by_expansion, 'logs': logs, 'tab_id': tab_id })
+
+def try_match_spirit(game, spirit_spec):
+    if not spirit_spec:
+        return None
+
+    if spirit_spec.isnumeric():
+        spirit_spec = int(spirit_spec)
+        player_ids = game.gameplayer_set.values_list('id', flat=True)
+        if 1 <= spirit_spec <= len(player_ids):
+            return player_ids[spirit_spec - 1]
+        elif spirit_spec in player_ids:
+            return spirit_spec
+    else:
+        aspect_match = game.gameplayer_set.filter(aspect__iexact=spirit_spec)
+        if aspect_match.exists():
+            return aspect_match.first().id
+        # prefer the base spirit if they search for a spirit name,
+        # in case there is one base and one aspected spirit in the same game.
+        base_spirit_match = game.gameplayer_set.filter(spirit__name__iexact=spirit_spec, aspect=None)
+        if base_spirit_match.exists():
+            return base_spirit_match.first().id
+        spirit_match = game.gameplayer_set.filter(spirit__name__iexact=spirit_spec)
+        if spirit_match.exists():
+            return spirit_match.first().id
+
+        # look for an exact match first, in case someone's name is a substring of another
+        # on the other hand, if someone's name is exactly a spirit or aspect's name, not much we can do!
+        player_exact_match = game.gameplayer_set.filter(name__iexact=spirit_spec)
+        if player_exact_match.exists():
+            return player_exact_match.first().id
+        player_match = game.gameplayer_set.filter(name__icontains=spirit_spec)
+        if player_match.exists():
+            return player_match.first().id
 
 def draw_cards(request, game_id, type):
     game = get_object_or_404(Game, pk=game_id)


### PR DESCRIPTION
This allows individual players to bookmark the URL for their own spirit and always be directed to their appropriate tab when visiting that URL.

Partial solution to
https://github.com/nathanj/spirit-island-pbp/issues/102

A full solution would involve cookies of some sort, but this is an easy-to-implement partial solution for now.