### PR TITLE
move show deck buttons next to gain power buttons

### DIFF
--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -27,13 +27,6 @@
 
 	<hr />
 
-  <button class="btn" hx-get="{% url 'minor_deck' game.id %}" hx-target="#Minor-deck">Show minor deck ({{game.minor_deck.count}} cards)</button>
-  <button class="btn" hx-get="{% url 'major_deck' game.id %}" hx-target="#Major-deck">Show major deck ({{game.major_deck.count}} cards)</button>
-  <div id="Minor-deck"></div>
-  <div id="Major-deck"></div>
-
-	<hr />
-
 	<h3>Host Actions:</h3>
 
 	<form enctype="multipart/form-data" method="post" action="{% url 'add_screenshot' game.id %}">

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -27,13 +27,10 @@
 
 	<hr />
 
-  <div id="minor-deck" hx-target="#minor-deck" hx-swap="outerHTML">
-    <button class="btn" hx-get="{% url 'minor_deck' game.id %}">Show minor deck ({{game.minor_deck.count}} cards)</button>
-  </div>
-
-  <div id="major-deck" hx-target="#major-deck" hx-swap="outerHTML">
-    <button class="btn" hx-get="{% url 'major_deck' game.id %}">Show major deck ({{game.major_deck.count}} cards)</button>
-  </div>
+  <button class="btn" hx-get="{% url 'minor_deck' game.id %}" hx-target="#Minor-deck">Show minor deck ({{game.minor_deck.count}} cards)</button>
+  <button class="btn" hx-get="{% url 'major_deck' game.id %}" hx-target="#Major-deck">Show major deck ({{game.major_deck.count}} cards)</button>
+  <div id="Minor-deck"></div>
+  <div id="Major-deck"></div>
 
 	<hr />
 

--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -151,6 +151,9 @@
   {% endif %}
   <button class="btn" hx-get="{% url 'take_powers' player.id 'minor' '1' %}">1 Card</button>
 
+  <button class="btn" hx-get="{% url 'minor_deck' player.game.id %}" hx-target="#Minor-deck" hx-swap="innerHTML">Show deck</button>
+  <div id="Minor-deck"></div>
+
   <p>Gain Major ({{ player.game.major_deck.count }} in deck):
   {% if player.aspect == 'Mentor' %}
   <button class="btn" hx-get="{% url 'take_powers' player.id 'major' '2' %}">2 Cards (keep 2)</button>
@@ -163,6 +166,9 @@
   <button class="btn" hx-get="{% url 'gain_power' player.id 'major' '2' %}">2 Cards</button>
   {% endif %}
   <button class="btn" hx-get="{% url 'take_powers' player.id 'major' '1' %}">1 Card</button>
+
+  <button class="btn" hx-get="{% url 'major_deck' player.game.id %}" hx-target="#Major-deck" hx-swap="innerHTML">Show deck</button>
+  <div id="Major-deck"></div>
 
   {% if player.spirit.name == 'Waters' %}
   <p>Gain Healing Card: <button class="btn" hx-get="{% url 'gain_healing' player.id %}">Gain Healing Card</button>

--- a/pbf/templates/power_deck.html
+++ b/pbf/templates/power_deck.html
@@ -2,6 +2,7 @@
 
 <p>
 <h4>{{ name }} deck ({{ cards | length }} cards):</h4>
+<button class="btn" onClick="document.getElementById('{{name}}-deck').innerHTML='';">Close</button>
 <ul>
   <div class="container-fluid">
     <div class="row">
@@ -15,3 +16,5 @@
     </div>
   </div>
 </ul>
+<button class="btn" onClick="document.getElementById('{{name}}-deck').innerHTML='';">Close</button>
+</p>


### PR DESCRIPTION
This seems sensible because then operations related to the decks are all in one place.

Closes https://github.com/nathanj/spirit-island-pbp/issues/141