### PR TITLE
notify of errors on $follow: errors when pinning, invalid URL

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -132,10 +132,10 @@ async def on_message(message):
     parts = message.content.split()
     if len(parts) >= 2 and parts[0] == '$follow':
         argument = parts[1]
-        await message.pin()
         guid = await updatethings(message.channel, argument)
         if not guid:
             await message.channel.send(f"That doesn't look like a game URL. Did you provide the full URL https://{GAME_URL}/game/abcd1234... ?")
+        await message.pin()
     if message.content.startswith('$help'):
         # The message starts with the specified word
         LOG.msg(f'$help called')

--- a/bot.py
+++ b/bot.py
@@ -112,6 +112,7 @@ async def updatethings(after,topic):
         await after.send(f'Now relaying game log for {guid} to this channel. Good luck!')
         r = requests.post(f'http://{DJANGO_HOST}:{DJANGO_PORT}/api/game/{guid}/link/{after.id}')
         LOG.msg(r)
+        return guid
 
 @client.event
 async def on_guild_channel_update(before, after):
@@ -132,7 +133,9 @@ async def on_message(message):
     if len(parts) >= 2 and parts[0] == '$follow':
         argument = parts[1]
         await message.pin()
-        await updatethings(message.channel, argument)
+        guid = await updatethings(message.channel, argument)
+        if not guid:
+            await message.channel.send(f"That doesn't look like a game URL. Did you provide the full URL https://{GAME_URL}/game/abcd1234... ?")
     if message.content.startswith('$help'):
         # The message starts with the specified word
         LOG.msg(f'$help called')

--- a/bot.py
+++ b/bot.py
@@ -136,7 +136,12 @@ async def on_message(message):
         if not guid:
             await message.channel.send(f"That doesn't look like a game URL. Did you provide the full URL https://{GAME_URL}/game/abcd1234... ?")
             return
-        await message.pin()
+        try:
+            await message.pin()
+        except discord.Forbidden:
+            await message.channel.send("I don't have permission to pin messages, so you'll have to pin the link yourself, but I'll still relay game logs.")
+        except discord.HTTPException:
+            await message.channel.send("Failed to pin the message due to an HTTP error, so you'll have to pin the link yourself, but I'll still relay game logs.")
     if message.content.startswith('$help'):
         # The message starts with the specified word
         LOG.msg(f'$help called')

--- a/bot.py
+++ b/bot.py
@@ -135,6 +135,7 @@ async def on_message(message):
         guid = await updatethings(message.channel, argument)
         if not guid:
             await message.channel.send(f"That doesn't look like a game URL. Did you provide the full URL https://{GAME_URL}/game/abcd1234... ?")
+            return
         await message.pin()
     if message.content.startswith('$help'):
         # The message starts with the specified word


### PR DESCRIPTION
Together, these help debug errors when setting up and running a new instance of the bot.

It also allows the bot to attempt to follow the game even if pinning failed, e.g. if a guild intentionally denies the bot the ability to pin messages.

closes https://github.com/nathanj/spirit-island-pbp/issues/36