### PR TITLE
templates/player: add confirmation to forget from impending

### DIFF
--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -288,7 +288,7 @@
 	      </div>
 	      <div class="text-center pb-5">
 		    <button class="btn" hx-get="{% url 'unimpend_card' player.id i.card.id %}">Unimpend</button>
-		    <button class="btn" hx-get="{% url 'forget_card' player.id i.card.id %}">Forget</button>
+		    <button class="btn" hx-get="{% url 'forget_card' player.id i.card.id %}" hx-confirm="Are you sure?">Forget</button>
 	      </div>
 	    </div>
 	  </div>


### PR DESCRIPTION
All other forget buttons have this confirmation, so this matches the experience.

It's relatively rare to forget from impending anyway. You can only do it to gain a major, not to pay for an aided by element event.