### PR TITLE
remove unneeded calls to compute_card_thresholds

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -1015,7 +1015,6 @@ def change_energy(request, player_id, amount):
     player.energy += amount
     player.save()
 
-    compute_card_thresholds(player)
     return with_log_trigger(render(request, 'energy.html', {'player': player}))
 
 def pay_energy(request, player_id):
@@ -1025,7 +1024,6 @@ def pay_energy(request, player_id):
     player.paid_this_turn = True
     player.save()
 
-    compute_card_thresholds(player)
     return with_log_trigger(render(request, 'energy.html', {'player': player}))
 
 def gain_energy(request, player_id):
@@ -1035,7 +1033,6 @@ def gain_energy(request, player_id):
     player.gained_this_turn = True
     player.save()
 
-    compute_card_thresholds(player)
     return with_log_trigger(render(request, 'energy.html', {'player': player}))
 
 def change_spirit_specific_resource(request, player_id, amount):
@@ -1047,9 +1044,6 @@ def change_spirit_specific_resource(request, player_id, amount):
     elif amount < 0:
         player.spirit_specific_per_turn_flags |= GamePlayer.SPIRIT_SPECIFIC_DECREMENTED_THIS_TURN
     player.save()
-
-    # As of this writing, no resource affects card thresholds.
-    # compute_card_thresholds(player)
 
     # The spirit-specific resource is displayed in energy.html,
     # because some of them can change simultaneously with energy (e.g. Rot).


### PR DESCRIPTION
you don't need these when rendering energy.html, energy.html doesn't read anything that compute_card_thresholds changes (the _cards variables, nor computed_thresholds)