### PR TITLE
show threshold check/x on impending cards

### DIFF
--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -268,11 +268,18 @@
   <ul>
     <div class="container-fluid">
       <div class="row">
-	{% for i in player.gameplayerimpendingwithenergy_set.all %}
+	{% for i in player.computed_impending %}
 	<div class="col-auto">
 	  <div class="w-100 w-md-200 mw-full">
 	    <div class="card p-0 m-5 m-md-10" {% if i.in_play %}style="background-color: #040;"{% endif %}>
-	      <img src="{% static i.card.url %}" class="img-fluid rounded-top" alt="{{i.card.name}}">
+	      <div style="position: relative">
+
+		{% for threshold in i.card.computed_thresholds %}
+		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% if threshold.achieved %}{% static "pbf/green.png" %}{% else %}{% static "pbf/red.svg" %}{% endif %}" />
+		{% endfor %}
+
+		<img src="{% static i.card.url %}" class="img-fluid rounded-top" alt="{{i.card.name}}">
+	      </div>
 	      <div class="text-center pb-5">
 		    <button class="btn" hx-get="{% url 'add_energy_to_impending' player.id i.card.id %}" {% if i.in_play or i.energy >= i.cost_with_scenario %}disabled{% endif %}>+1</button>
 			{% if i.energy >= i.cost_with_scenario %}

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -774,6 +774,10 @@ def compute_card_thresholds(player):
         if card.is_healing():
             card.computed_thresholds.extend(card.healing_thresholds(player.healing.count(), player.spirit_specific_resource_elements()))
         player.selection_cards.append(card)
+    # we could just unconditionally set this, but I guess we'll save a database query if they're not Dances Up Earthquakes.
+    player.computed_impending = player.gameplayerimpendingwithenergy_set.all() if player.spirit.name == 'Earthquakes' else []
+    for imp in player.computed_impending:
+        imp.card.computed_thresholds = imp.card.thresholds(player.elements, equiv_elements)
 
 def gain_energy_on_impending(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)


### PR DESCRIPTION
Otherwise, players don't know whether they've reached the thresholds.

Since https://github.com/nathanj/spirit-island-pbp/pull/31 this has become more important.

Before that change, the card would move from the impending area to the play area, where the indicators would be shown.

However, now they stay in the impending area, so there is no opportunity to see the indicators.