### PR TITLE
support CORS (Cross-Origin Resource Sharing)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -29,6 +29,9 @@ DEBUG = "yes"
 # Optional setting for development, required for production
 #DJANGO_SECRET_KEY = ""  # secret key for Django; empty will use dev secret in island/settings.py
 
+# Optional setting: External sites allowed to make API requests (comma-separated list, including http:// or https:// scheme)
+#CORS_ALLOWED_HOSTS = ''
+
 #Optional setting to be used if Django is running on a non-default host/port (e.g. Docker)
 #used by the bot to connect to Django; doesn't itself control where Django runs
 #DJANGO_HOST = "localhost"

--- a/island/settings.py
+++ b/island/settings.py
@@ -40,6 +40,8 @@ if 'EXTRA_ALLOWED_HOSTS' in os.environ:
     for url in os.environ['EXTRA_ALLOWED_HOSTS'].split(','):
         CSRF_TRUSTED_ORIGINS.extend([f'https://{url}', f'http://{url}'])
 
+CORS_ALLOWED_ORIGINS = os.environ['CORS_ALLOWED_ORIGINS'].split(',') if 'CORS_ALLOWED_ORIGINS' in os.environ and os.environ['CORS_ALLOWED_ORIGINS'] else []
+
 # Application definition
 
 INSTALLED_APPS = [
@@ -49,6 +51,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'corsheaders',
     #'debug_toolbar',
     'django_prometheus',
     'pbf',
@@ -60,6 +63,7 @@ MIDDLEWARE = [
 
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "gunicorn>=26.0.0,<27",
     "python-dotenv>=1.0.0,<2",
     "django-prometheus>=2.2.0,<3",
+    "django-cors-headers>=4.9.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -354,6 +354,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-cors-headers"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/39/55822b15b7ec87410f34cd16ce04065ff390e50f9e29f31d6d116fc80456/django_cors_headers-4.9.0.tar.gz", hash = "sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8", size = 21458, upload-time = "2025-09-18T10:40:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d8/19ed1e47badf477d17fb177c1c19b5a21da0fd2d9f093f23be3fb86c5fab/django_cors_headers-4.9.0-py3-none-any.whl", hash = "sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449", size = 12809, upload-time = "2025-09-18T10:40:50.843Z" },
+]
+
+[[package]]
 name = "django-debug-toolbar"
 version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1061,6 +1074,7 @@ source = { editable = "." }
 dependencies = [
     { name = "django" },
     { name = "django-cleanup" },
+    { name = "django-cors-headers" },
     { name = "django-ninja" },
     { name = "django-prometheus" },
     { name = "gunicorn" },
@@ -1089,6 +1103,7 @@ typecheck = [
 requires-dist = [
     { name = "django", specifier = ">=6.0.0,<7" },
     { name = "django-cleanup", specifier = ">=9.0.0,<10" },
+    { name = "django-cors-headers", specifier = ">=4.9.0" },
     { name = "django-ninja", specifier = ">=1.0.0,<2" },
     { name = "django-prometheus", specifier = ">=2.2.0,<3" },
     { name = "gunicorn", specifier = ">=26.0.0,<27" },


### PR DESCRIPTION
The site administrator will be able to allow external sites to make requests to this site.

To test, send the following request to the server:

    curl -H "Access-Control-Request-Method: GET" -H "Origin: https://www.example.com" --head http://localhost:8000 | grep -i 'access-control-allow-origin\|$'

Look for the presence or absence of access-control-allow-origin header in the response.

The header will only be present if the CORS_ALLOWED_ORIGINS was set to include https://www.example.com

Closes https://github.com/nathanj/spirit-island-pbp/issues/162 assuming that the site admininstrators also allows the external site there mentioned.