### PR TITLE
install django-cleanup to clean old screenshots

### DIFF
--- a/island/settings.py
+++ b/island/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     #'debug_toolbar',
     'django_prometheus',
     'pbf',
+    'django_cleanup.apps.CleanupConfig',
 ]
 
 MIDDLEWARE = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -378,6 +378,17 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "django-cleanup"
+version = "9.0.0"
+description = "Deletes old files."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_cleanup-9.0.0-py3-none-any.whl", hash = "sha256:19f8b0e830233f9f0f683b17181f414672a0f48afe3ea3cc80ba47ae40ad880c"},
+    {file = "django_cleanup-9.0.0.tar.gz", hash = "sha256:bb9fb560aaf62959c81e31fa40885c36bbd5854d5aa21b90df2c7e4ba633531e"},
+]
+
+[[package]]
 name = "django-debug-toolbar"
 version = "3.8.1"
 description = "A configurable set of panels that display various debug information about the current request/response."
@@ -1058,4 +1069,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3eba81eeeb1f0c93386800dd5d0d34e33fe694b66f7ddd3df79b5b4cbe16cd51"
+content-hash = "fef1ca08e212729b9d47d68a126cf2a20282a1d0370e949081b3716a5910bef3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Nathan Jones <nathanj439@gmail.com>"]
 python = "^3.8"
 Django = "^4.0.1"
 django-debug-toolbar = "^3.2.4"
+django-cleanup = "^9.0.0"
 Pillow = "^9.0.0"
 django-ninja = "^0.16.1"
 gunicorn = "^20.1.0"


### PR DESCRIPTION
Each game only keeps its two current screenshots; as soon as a new screenshot is loaded, the old files are orphaned.

Rather than leaving these orphaned files around, we should delete them to save space.

It's safe to do this as we don't need to keep any files for archival purposes; the files would have also been sent to the game channel.