### PR TITLE
bot: remove extraneous f from fake-discord outputs

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -70,9 +70,9 @@ if '--fake-discord' in sys.argv:
 
             async def send(self, msg, file=None):
                 if file:
-                    print(f"send f{self.id}: {msg} file: {file.filename}")
+                    print(f"send {self.id}: {msg} file: {file.filename}")
                 else:
-                    print(f"send f{self.id}: {msg}")
+                    print(f"send {self.id}: {msg}")
 
         def event(self, f):
             return f


### PR DESCRIPTION
must have accidentally left them in from when the format string didn't start with "send"