### PR TITLE
discard top N powers: default to 0, add button for # of players, use radio instead of select

### DIFF
--- a/pbf/static/pbf/sipbp.css
+++ b/pbf/static/pbf/sipbp.css
@@ -25,6 +25,9 @@ form#add-spirit-form img.ms-dd-option-image {
 	margin-bottom: 5px;
 }
 
+form#host-draw {
+	margin-top: 1.5em;
+}
 form#host-draw div {
 	display: flex;
 	align-items: center;

--- a/pbf/static/pbf/sipbp.css
+++ b/pbf/static/pbf/sipbp.css
@@ -37,6 +37,9 @@ form#host-draw div div {
 	margin-right: 5px;
 	flex-direction: column;
 }
+form#host-draw label {
+	margin-left: 5px;
+}
 
 @media screen and (max-device-width:1400px), screen and (max-width:1400px) {
 	.spirit-image-single {

--- a/pbf/static/pbf/sipbp.css
+++ b/pbf/static/pbf/sipbp.css
@@ -25,6 +25,16 @@ form#add-spirit-form img.ms-dd-option-image {
 	margin-bottom: 5px;
 }
 
+form#host-draw div {
+	display: flex;
+	align-items: center;
+}
+form#host-draw div div {
+	margin-left: 5px;
+	margin-right: 5px;
+	flex-direction: column;
+}
+
 @media screen and (max-device-width:1400px), screen and (max-width:1400px) {
 	.spirit-image-single {
 		/* A spirit panel is by default 630 pixels. We multiply 630 * 0.8 to arrive at the below number.

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -43,16 +43,21 @@
 	  <button type="submit" class="btn">Upload Screenshot 2</button>
 	</form>
 
-  <form id="host-draw" hx-swap="afterend" hx-indicator="#host-draw-spinner">
+  <form id="host-draw" hx-target="#host-draw" hx-swap="afterend" hx-indicator="#host-draw-spinner">
     {# csrf_token not needed because we've configured HTMX to send the token in the header #}
-    Discard top <input type="number" name="num_cards" min="1" max="100" value="{{game.gameplayer_set.count}}" />
-    <select name="type">
-      <option value="minor">minor</option>
-      <option value="major">major</option>
-    </select>
-    power cards:
-    <button type="submit" class="btn" hx-post="{% url 'draw_cards' game.id %}">Discard</button>
-    <span id="host-draw-spinner" class="htmx-indicator"><img src="{% static "pbf/bars.svg" %}" /></span>
+    <div>
+      Discard top
+      <div>
+        <input id="host-draw-num" type="number" name="num_cards" min="1" max="100" value="{{game.gameplayer_set.count}}" />
+      </div>
+      <select name="type">
+        <option value="minor">minor</option>
+        <option value="major">major</option>
+      </select>
+      <div>power cards:</div>
+      <button type="submit" class="btn" hx-post="{% url 'draw_cards' game.id %}">Discard</button>
+      <span id="host-draw-spinner" class="htmx-indicator"><img src="{% static "pbf/bars.svg" %}" /></span>
+    </div>
   </form>
 
   <p><a href="{% url 'game_setup' game.id %}">Game setup</a></p>

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -51,10 +51,10 @@
         <input id="host-draw-num" type="number" name="num_cards" min="0" max="100" value="0" />
         <button onclick="document.getElementById('host-draw-num').value='{{game.gameplayer_set.count}}'; return false">Set to {{game.gameplayer_set.count}}</button>
       </div>
-      <select name="type">
-        <option value="minor">minor</option>
-        <option value="major">major</option>
-      </select>
+      <div>
+        <label><input type="radio" name="type" value="minor" checked> minor</label>
+        <label><input type="radio" name="type" value="major"> major</label>
+      </div>
       <div>power cards:</div>
       <button type="submit" class="btn" hx-post="{% url 'draw_cards' game.id %}">Discard</button>
       <span id="host-draw-spinner" class="htmx-indicator"><img src="{% static "pbf/bars.svg" %}" /></span>

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -48,7 +48,8 @@
     <div>
       Discard top
       <div>
-        <input id="host-draw-num" type="number" name="num_cards" min="1" max="100" value="{{game.gameplayer_set.count}}" />
+        <input id="host-draw-num" type="number" name="num_cards" min="0" max="100" value="0" />
+        <button onclick="document.getElementById('host-draw-num').value='{{game.gameplayer_set.count}}'; return false">Set to {{game.gameplayer_set.count}}</button>
       </div>
       <select name="type">
         <option value="minor">minor</option>

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -46,7 +46,7 @@
   <form id="host-draw" hx-target="#host-draw" hx-swap="afterend" hx-indicator="#host-draw-spinner">
     {# csrf_token not needed because we've configured HTMX to send the token in the header #}
     <div>
-      Discard top
+      <label for="host-draw-num">Discard top</label>
       <div>
         <input id="host-draw-num" type="number" name="num_cards" min="0" max="100" value="0" />
         <button onclick="document.getElementById('host-draw-num').value='{{game.gameplayer_set.count}}'; return false">Set to {{game.gameplayer_set.count}}</button>


### PR DESCRIPTION
Avoids accidentally invoking the functionality when unintended while hopefully still being convenient.