### PR TITLE
Add log messages for impending actions

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -1139,7 +1139,8 @@ def ready(request, player_id):
     return with_log_trigger(render(request, 'player.html', {'player': player}))
 
 def add_impending_log_msgs(player):
-    for impended_card_with_energy in player.gameplayerimpendingwithenergy_set.all():
+    for impended_card_with_energy in player.gameplayerimpendingwithenergy_set.all().prefetch_related('card'):
+        card = impended_card_with_energy.card
         if impended_card_with_energy.this_turn:
             add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} impends {card.name}')
         elif impended_card_with_energy.in_play:


### PR DESCRIPTION
Adds log messages for the following DUE actions:
- Impend or Unimpend card
- Add or remove energy (including noting whether it's put into play)
- manually play or unplay card

Example screenshots: 

![image](https://github.com/user-attachments/assets/fd80afcc-38af-497b-9581-8a1284ee460c)

![image](https://github.com/user-attachments/assets/208fb06a-4b7e-4728-af62-208b84c9d3c1)

![image](https://github.com/user-attachments/assets/ac123875-21b8-4768-ac26-9386b85a4573)

![image](https://github.com/user-attachments/assets/12933e83-b460-4b2b-a184-2ee3df0e2cc2)

![image](https://github.com/user-attachments/assets/52801564-a668-455e-951c-43b07e4e2c15)
