### PR TITLE
island/urls: Only add view_screenshot in DEBUG

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,8 +5,9 @@ DISCORD_KEY="insert bot token here"
 # Debug mode is useful when testing locally.
 # It will show detailed error pages,
 # and also make Django serve static files (https://docs.djangoproject.com/en/stable/howto/static-files/)
+# and uploaded files (screenshots)
 # Remember to disable when running in production.
-# Used in island/settings.py
+# Used in island/settings.py and island/urls.py
 DEBUG="yes" 
 
 #Optional Setting; In case your internal IP is not being recognised by the bot. Used in pbf/api.py for interaction between discord bot and bitcrafter Django

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ A full treatment of this topic is beyond the scope of this document, but here ar
 * Remember to turn `DEBUG` off in the `.env` file.
 * `poetry run ./manage.py collectstatic` will copy all [static files](https://docs.djangoproject.com/en/stable/howto/static-files/) into `static/`.
   You will need to configure your web server to serve static files out of this directory.
+* You will also need to configure your web server to serve uploaded files out of the `screenshots/` directory.
 * This repo already contains all the necessary configuration to be run by [Gunicorn](https://gunicorn.org/).
 * [Gunicorn deployment docs](https://docs.gunicorn.org/en/latest/deploy.html) recommend deploying Gunicorn behind a proxy server.
   They themselves recommend [nginx](https://nginx.org/).

--- a/island/urls.py
+++ b/island/urls.py
@@ -11,8 +11,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path("api/", api.urls),
     path('', views.home, name='home'),
-    path('screenshot/<str:filename>', views.view_screenshot, name='view_screenshot'),
-    path('screenshot/<str:game_id>/<str:filename>', views.view_screenshot, name='view_screenshot'),
     path('new', views.new_game, name='new_game'),
     path('import', views.import_game, name='import_game'),
     path('game/<str:game_id>', views.view_game, name='view_game'),
@@ -66,3 +64,9 @@ urlpatterns = [
     path('game/<int:player_id>/element-permanent/<str:element>/add', views.add_element_permanent, name='add_element_permanent'),
     path('game/<int:player_id>/element-permanent/<str:element>/remove', views.remove_element_permanent, name='remove_element_permanent'),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+if settings.DEBUG:
+    urlpatterns += [
+        path('screenshot/<str:filename>', views.view_screenshot, name='view_screenshot'),
+        path('screenshot/<str:game_id>/<str:filename>', views.view_screenshot, name='view_screenshot'),
+    ]

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -43,6 +43,7 @@ def home(request):
     games = Game.objects.all()
     return render(request, 'index.html', { 'games': games })
 
+# For use in development only, not production.
 def view_screenshot(request, game_id=None, filename=None):
     with open(os.path.join(*[s for s in ['screenshot', game_id, filename] if s]), mode='rb') as f:
         return HttpResponse(f.read(), content_type='image/jpeg')


### PR DESCRIPTION
want to remove all doubt about the intention of this endpoint and remove any chance that it accidentally gets called in production