### PR TITLE
templates/player: deduplicate common parts of thresholds

### DIFF
--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -80,11 +80,7 @@
 	{% endfor %}
       {% endif %}
       {% for threshold in player.thresholds %}
-      {% if threshold.achieved %}
-      <img style="position: absolute; left: {{threshold.x}}px; top: {{threshold.y}}px;" src="{% static "pbf/green.png" %}" width="20" height="20" />
-      {% else %}
-      <img style="position: absolute; left: {{threshold.x}}px; top: {{threshold.y}}px;" src="{% static "pbf/red.svg" %}" width="20" height="20" />
-      {% endif %}
+      <img style="position: absolute; left: {{threshold.x}}px; top: {{threshold.y}}px;" src="{% if threshold.achieved %}{% static "pbf/green.png" %}{% else %}{% static "pbf/red.svg" %}{% endif %}" width="20" height="20" />
       {% endfor %}
       <img src="{% static player.spirit.url %}" width="957" height="{% if player.spirit.name == "Covets" %}1260{% else %}630{% endif %}" />
     </div>
@@ -118,11 +114,7 @@
 	    <div class="card p-0 m-5 m-md-10">
 	      <div style="position: relative">
 		{% for threshold in card.computed_thresholds %}
-		{% if threshold.achieved %}
-		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% static "pbf/green.png" %}" />
-		{% else %}
-		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% static "pbf/red.svg" %}" />
-		{% endif %}
+		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% if threshold.achieved %}{% static "pbf/green.png" %}{% else %}{% static "pbf/red.svg" %}{% endif %}" />
 		{% endfor %}
 		<img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
 	      </div>
@@ -214,11 +206,7 @@
 	      <div style="position: relative">
 
 		{% for threshold in card.computed_thresholds %}
-		{% if threshold.achieved %}
-		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% static "pbf/green.png" %}" />
-		{% else %}
-		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% static "pbf/red.svg" %}" />
-		{% endif %}
+		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% if threshold.achieved %}{% static "pbf/green.png" %}{% else %}{% static "pbf/red.svg" %}{% endif %}" />
 		{% endfor %}
 
 		<img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">
@@ -239,11 +227,7 @@
 	      <div style="position: relative">
 
 		{% for threshold in card.computed_thresholds %}
-		{% if threshold.achieved %}
-		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% static "pbf/green.png" %}" />
-		{% else %}
-		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% static "pbf/red.svg" %}" />
-		{% endif %}
+		<img style="position: absolute; left: {{threshold.x}}%; top: {{threshold.y}}%; width: 2vmin; height: 2vmin;" src="{% if threshold.achieved %}{% static "pbf/green.png" %}{% else %}{% static "pbf/red.svg" %}{% endif %}" />
 		{% endfor %}
 
 		<img src="{% static card.url %}" class="img-fluid rounded-top" alt="{{card.name}}">


### PR DESCRIPTION
the parts for threshold achieved and not achieved differeed only in the img src, so it's better to make it clearer to the reader that that is the only way they differ, rather than force the reader to manually compare the two lines to make sure of this.

This change isn't just being made capriciously. I soon need to make some changes to these marks, and deduplicating the common portions halves the number of places where changes need to be made.