### PR TITLE
remove requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-discord
-structlog
-async_timeout
-load_dotenv
-pillow
-redis


### PR DESCRIPTION
it's extra work to have to keep dependencies up to date in two places. all our dependencies should be declared in pyproject.toml