### PR TITLE
update dependency redis 4.6.0 -> 5.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1097,21 +1097,21 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "redis"
-version = "4.6.0"
+version = "5.2.1"
 description = "Python client for Redis database and key-value store"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c"},
-    {file = "redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d"},
+    {file = "redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4"},
+    {file = "redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f"},
 ]
 
 [package.dependencies]
-async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
 
 [package.extras]
-hiredis = ["hiredis (>=1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+hiredis = ["hiredis (>=3.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "requests"
@@ -1337,4 +1337,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8e134aafb22cc8000e56b59f63154799a9aa37606b2ad32a53229897c6625535"
+content-hash = "b87b435eea2f757f8435f019bba11a9a6fb31bfa57e87f8c5838c2282fdbddba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,13 @@ requests = "^2.0.0"
 # structlog uses calendar versioning,
 # so using ^ is unnecessarily restrictive
 structlog = ">= 25.1.0"
-redis = "^4.2.0"
+# 6.0.0 and above only officially supports Redis 7.2, 7.4, and 8.0.
+# We've unofficially observed that it will still work for older versions,
+# but need more data before being able to rely on this.
+# We don't need the token auth functionality of 5.3.0,
+# and it introduces a dependency on pyjwt that we don't need,
+# so we'll skip that to keep fewer dependencies.
+redis = "~5.2"
 django-prometheus = "^2.2.0"
 # TODO: remove this dependency once all installations are using Python 3.11,
 # since 3.11 has asyncio.timeout in the standard library


### PR DESCRIPTION
https://github.com/redis/redis-py/releases

Note the comment about the supported Redis version associated with each library version, which comes from:
https://github.com/redis/redis-py/blob/master/README.md#supported-redis-versions

Test plan:
Run the site and bot and observe that the bot still receives updates from the site