### PR TITLE
Dep django

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1097,21 +1097,21 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "redis"
-version = "4.6.0"
+version = "5.2.1"
 description = "Python client for Redis database and key-value store"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c"},
-    {file = "redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d"},
+    {file = "redis-5.2.1-py3-none-any.whl", hash = "sha256:ee7e1056b9aea0f04c6c2ed59452947f34c4940ee025f5dd83e6a6418b6989e4"},
+    {file = "redis-5.2.1.tar.gz", hash = "sha256:16f2e22dff21d5125e8481515e386711a34cbec50f0e44413dd7d9c060a54e0f"},
 ]
 
 [package.dependencies]
-async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+async-timeout = {version = ">=4.0.3", markers = "python_full_version < \"3.11.3\""}
 
 [package.extras]
-hiredis = ["hiredis (>=1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+hiredis = ["hiredis (>=3.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "requests"
@@ -1337,4 +1337,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8e134aafb22cc8000e56b59f63154799a9aa37606b2ad32a53229897c6625535"
+content-hash = "b87b435eea2f757f8435f019bba11a9a6fb31bfa57e87f8c5838c2282fdbddba"

--- a/poetry.lock
+++ b/poetry.lock
@@ -369,17 +369,17 @@ voice = ["PyNaCl (>=1.3.0,<1.6)"]
 
 [[package]]
 name = "django"
-version = "4.2.16"
+version = "5.2.3"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "Django-4.2.16-py3-none-any.whl", hash = "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898"},
-    {file = "Django-4.2.16.tar.gz", hash = "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"},
+    {file = "django-5.2.3-py3-none-any.whl", hash = "sha256:c517a6334e0fd940066aa9467b29401b93c37cec2e61365d663b80922542069d"},
+    {file = "django-5.2.3.tar.gz", hash = "sha256:335213277666ab2c5cac44a792a6d2f3d58eb79a80c14b6b160cd4afc3b75684"},
 ]
 
 [package.dependencies]
-asgiref = ">=3.6.0,<4"
+asgiref = ">=3.8.1"
 sqlparse = ">=0.3.1"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
@@ -1336,5 +1336,5 @@ propcache = ">=0.2.1"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "b87b435eea2f757f8435f019bba11a9a6fb31bfa57e87f8c5838c2282fdbddba"
+python-versions = "^3.10"
+content-hash = "59f236ff70ed02673ca338caa03d9bf62f384d2818675a325d0e080cab4f4f9c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,13 @@ requests = "^2.0.0"
 # structlog uses calendar versioning,
 # so using ^ is unnecessarily restrictive
 structlog = ">= 25.1.0"
-redis = "^4.2.0"
+# 6.0.0 and above only officially supports Redis 7.2, 7.4, and 8.0.
+# We've unofficially observed that it will still work for older versions,
+# but need more data before being able to rely on this.
+# We don't need the token auth functionality of 5.3.0,
+# and it introduces a dependency on pyjwt that we don't need,
+# so we'll skip that to keep fewer dependencies.
+redis = "~5.2"
 django-prometheus = "^2.2.0"
 # TODO: remove this dependency once all installations are using Python 3.11,
 # since 3.11 has asyncio.timeout in the standard library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = ""
 authors = ["Nathan Jones <nathanj439@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-Django = "^4.0.1"
+python = "^3.10"
+Django = "^5.0.0"
 django-debug-toolbar = "^5.0.0"
 django-cleanup = "^9.0.0"
 Pillow = "^11.0.0"


### PR DESCRIPTION
I chose to include the redis update in this branch because they both update the `content-hash` line, but this pull request is intended to examine only the django dependency change

Django 5.0 dropped support for Python 3.9.

A read through all the release changes doesn't seem to reveal any
backwards-incompatible changes that affect this project.

https://docs.djangoproject.com/en/5.2/releases/
https://docs.djangoproject.com/en/5.2/releases/5.0/
https://docs.djangoproject.com/en/5.2/releases/5.1/
https://docs.djangoproject.com/en/5.2/releases/5.2/

Test plan:
Run the site and check that all operations still work