### PR TITLE
.env.template: Give example si.bitcrafter.net for EXTRA_ALLOWED_HOSTS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,7 +15,7 @@ DEBUG="yes"
 ALLOWED_IPS="127.0.0.1"
 
 #Optional Setting; In case you're hosting somewhere other than si.bitcrafter.net or localhost. Used in island/settings.py
-EXTRA_ALLOWED_HOSTS = "*"
+EXTRA_ALLOWED_HOSTS = "si.bitcrafter.net"
 
 #Optional Setting; For regex matching the game URLs for the bot to recognise it as valid. Used in bot,py
 GAME_URL = "si.bitcrafter.net"


### PR DESCRIPTION
It doesn't seem to make sense to advise the use of * unless the administrator has made sure this makes sense for their environment.

This also helps administrators understand what kind of value should be put in this field: just the hostname, and not the protocol.