### PR TITLE
reshuffle_discard: reject an invalid deck type; move all cards at once

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -715,11 +715,13 @@ def reshuffle_discard(game, type):
         for card in minors:
             game.discard_pile.remove(card)
             game.minor_deck.add(card)
-    else:
+    elif type == 'major':
         majors = game.discard_pile.filter(type=Card.MAJOR).all()
         for card in majors:
             game.discard_pile.remove(card)
             game.major_deck.add(card)
+    else:
+        raise ValueError(f"can't reshuffle {type} deck")
 
     add_log_msg(game, text=f'Re-shuffling {type} power deck')
 

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -712,14 +712,12 @@ def cards_from_deck(game, cards_needed, type):
 def reshuffle_discard(game, type):
     if type == 'minor':
         minors = game.discard_pile.filter(type=Card.MINOR).all()
-        for card in minors:
-            game.discard_pile.remove(card)
-            game.minor_deck.add(card)
+        game.discard_pile.remove(*minors)
+        game.minor_deck.add(*minors)
     elif type == 'major':
         majors = game.discard_pile.filter(type=Card.MAJOR).all()
-        for card in majors:
-            game.discard_pile.remove(card)
-            game.major_deck.add(card)
+        game.discard_pile.remove(*majors)
+        game.major_deck.add(*majors)
     else:
         raise ValueError(f"can't reshuffle {type} deck")
 


### PR DESCRIPTION
this shouldn't actually happen because its only caller, card_from_deck, will already reject invalid deck type, but we should e consistent in applying this enforcement and apply it in both places instead of only one.

---

moving all cards at once makes reshuffle noticeably faster