### PR TITLE
reclaim_all: move all cards at once

### DIFF
--- a/pbf/tests.py
+++ b/pbf/tests.py
@@ -416,6 +416,20 @@ class TestPlayCost(TestCase):
     def test_slow_blitz(self):
         self.assert_cost(['Call to Vigilance'], 2, scenario='Blitz')
 
+class TestReclaim(TestCase):
+    def test_reclaim_all(self):
+        game = Game()
+        game.save()
+        player = GamePlayer(game=game, spirit=Spirit.objects.get(name='River'))
+        player.save()
+        player.hand.set([Card.objects.get(name="Boon of Vigor"), Card.objects.get(name="Flash Floods")])
+        player.discard.set([Card.objects.get(name="River's Bounty"), Card.objects.get(name="Wash Away")])
+
+        Client().post(f"/game/{player.id}/reclaim/all")
+
+        self.assertEqual(4, player.hand.count())
+        self.assertEqual(0, player.discard.count())
+
 class TestElements(TestCase):
     def setup_game(self, card_names):
         game = Game()

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -1080,9 +1080,7 @@ def reclaim_card(request, player_id, card_id):
 
 def reclaim_all(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
-    cards = list(player.discard.all())
-    for card in cards:
-        player.hand.add(card)
+    player.hand.add(*player.discard.all())
     player.discard.clear()
 
     compute_card_thresholds(player)


### PR DESCRIPTION
This incurs fewer database queries. It's a noticeable speedup when reshuffling the minor or major power decks, but we'll apply it everywhere for consistency.