### PR TITLE
templates/elements: compute elements only once (fewer database queries)

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -430,6 +430,9 @@ class GamePlayer(models.Model):
         # which wouldn't be able to deconstruct a tuple of (total, temporary) in the value.
         return [(elt.name.lower(), elements[elt], getattr(self, 'temporary_' + elt.name.lower())) for elt in Elements]
 
+    def permanent_elements(self):
+        return {elt.name.lower(): getattr(self, 'permanent_' + elt.name.lower()) for elt in Elements}
+
     # Any code that creates a GamePlayer is expected to (manually) call this function once after creating it,
     # (currently add_player in views)
     # so it is suitable for any one-time setup.

--- a/pbf/templates/elements.html
+++ b/pbf/templates/elements.html
@@ -17,78 +17,14 @@
 
   <abbr title="Click the element to add a permanent element that will not be discarded at the end of the turn. Click the number in parentheses to decrease the number.">Permanent Elements</abbr>:
 
-  <a hx-get="{% url 'add_element_permanent' player.id 'sun' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-sun.png" %}" alt="sun" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_sun }}</span>
+  {% for elt, perm in player.permanent_elements.items %}
+  <a hx-get="{% url 'add_element_permanent' player.id elt %}" style="cursor: pointer">
+  {% with "pbf/element-"|add:elt|add:".png" as elt_img %}<img src="{% static elt_img %}" alt="{{elt}}" style="width: 1.8em; height: 1.8em" />{% endwith %}
+  <span style="font-size: 2em;">{{ perm }}</span>
   </a>
-  {% if player.permanent_sun > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'sun' %}">(+{{player.permanent_sun}})</a>
-  {% endif %}
+  {% if perm > 0 %}<a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id elt %}">(+{{perm}})</a>{% endif %}
   <span style="padding-right: 1em"></span>
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'moon' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-moon.png" %}" alt="moon" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_moon }}</span>
-  </a>
-  {% if player.permanent_moon > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'moon' %}">(+{{player.permanent_moon}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'fire' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-fire.png" %}" alt="fire" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_fire }}</span>
-  </a>
-  {% if player.permanent_fire > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'fire' %}">(+{{player.permanent_fire}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'air' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-air.png" %}" alt="air" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_air }}</span>
-  </a>
-  {% if player.permanent_air > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'air' %}">(+{{player.permanent_air}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'water' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-water.png" %}" alt="water" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_water }}</span>
-  </a>
-  {% if player.permanent_water > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'water' %}">(+{{player.permanent_water}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
-
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'earth' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-earth.png" %}" alt="earth" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_earth }}</span>
-  </a>
-  {% if player.permanent_earth > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'earth' %}">(+{{player.permanent_earth}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'plant' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-plant.png" %}" alt="plant" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_plant }}</span>
-  </a>
-  {% if player.permanent_plant > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'plant' %}">(+{{player.permanent_plant}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
-
-  <a hx-get="{% url 'add_element_permanent' player.id 'animal' %}" style="cursor: pointer">
-  <img src="{% static "pbf/element-animal.png" %}" alt="animal" style="width: 1.8em; height: 1.8em" />
-  <span style="font-size: 2em;">{{ player.permanent_animal }}</span>
-  </a>
-  {% if player.permanent_animal > 0 %}
-  <a style="color: gray; font-size: 0.8em; cursor: pointer;" hx-get="{% url 'remove_element_permanent' player.id 'animal' %}">(+{{player.permanent_animal}})</a>
-  {% endif %}
-  <span style="padding-right: 1em"></span>
+  {% endfor %}
 
   </p>
 </div>


### PR DESCRIPTION
Otherwise each of the individual properties (sun, moon, etc.) would
compute the elements once each, resulting in eight times as much work.
Since computing elements queries presence and cards played, the fewer
times we do it the better.

This also allows deduplicating some repetitive code