### PR TITLE
Game: provide player summary property

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -185,6 +185,10 @@ class Game(models.Model):
     def player_count(self):
         return self.gameplayer_set.count()
 
+    def player_summary(self):
+        players = self.gameplayer_set.values_list('id', 'name', 'spirit__name', 'aspect', 'color', named=True)
+        return [p._replace(color=colors_to_circle_color_map[p.color] if p.color else p.color) for p in players]
+
 colors_to_circle_color_map = {
         'blue': '#705dff',
         'green': '#0d9501',
@@ -391,9 +395,6 @@ class GamePlayer(models.Model):
 
     def disk_url(self):
         return 'pbf/disk_' + self.color + '.png'
-
-    def circle_color(self):
-        return colors_to_circle_color_map[self.color]
 
     @property
     def circle_emoji(self):

--- a/pbf/models.py
+++ b/pbf/models.py
@@ -181,6 +181,9 @@ class Game(models.Model):
         player_colors = Counter(self.gameplayer_set.values_list('color', flat=True))
         return [(c, player_colors[c], colors_to_circle_color_map[c]) for c in colors]
 
+    @functools.cached_property
+    def player_count(self):
+        return self.gameplayer_set.count()
 
 colors_to_circle_color_map = {
         'blue': '#705dff',

--- a/pbf/templates/game.html
+++ b/pbf/templates/game.html
@@ -21,7 +21,7 @@
 	</a>
 	{% endif %}
 
-	{% if game.gameplayer_set.count > 0 %}
+	{% if game.player_count %}
 	<div id="tabs" hx-get="{% url 'tab' game.id tab_id %}" hx-trigger="load after:100ms" hx-target="#tabs" hx-swap="innerHTML"></div>
 	{% endif %}
 
@@ -49,7 +49,7 @@
       <label for="host-draw-num">Discard top</label>
       <div>
         <input id="host-draw-num" type="number" name="num_cards" min="0" max="100" value="0" />
-        <button onclick="document.getElementById('host-draw-num').value='{{game.gameplayer_set.count}}'; return false">Set to {{game.gameplayer_set.count}}</button>
+        <button onclick="document.getElementById('host-draw-num').value='{{game.player_count}}'; return false">Set to {{game.player_count}}</button>
       </div>
       <div>
         <label><input type="radio" name="type" value="minor" checked> minor</label>

--- a/pbf/templates/setup.html
+++ b/pbf/templates/setup.html
@@ -21,25 +21,25 @@
     </tr>
   </thead>
   <tbody>
-    {% for player in game.gameplayer_set.all %}
+    {% for player in game.player_summary %}
     <tr>
-      {% with "pbf/spirit-icon-"|add:player.spirit.name|add:".png" as spirit_icon %}
-      <td><img src="{% static spirit_icon %}" alt="{{player.spirit.name}}" height="30" /></td>
+      {% with "pbf/spirit-icon-"|add:player.spirit__name|add:".png" as spirit_icon %}
+      <td><img src="{% static spirit_icon %}" alt="{{player.spirit__name}}" height="30" /></td>
       {% endwith %}
-      <td>{{player.spirit.name}}</td>
+      <td>{{player.spirit__name}}</td>
       <td>{% if player.aspect %}{{player.aspect}}{% endif %}</td>
       <td>
         <input type="hidden" name="id" value="{{player.id}}" />
         <input type="text" name="name" value="{{player.name}}" />
       </td>
       <td>
-        <select name="color" style="background-color: {{player.circle_color}};" onChange="this.style.backgroundColor = this.options[this.selectedIndex].style.backgroundColor">
+        <select name="color" style="background-color: {{player.color}};" onChange="this.style.backgroundColor = this.options[this.selectedIndex].style.backgroundColor">
           {% for color, freq, code in game.color_freq %}
           {# Probably not necessary to show in-use indicators. #}
           {# The host can see all the players in the table, #}
           {# so they are capable of making this judgment themselves. #}
           {# Besides, if we showed it we'd have to use JS to update it#}
-          <option style="background-color: {{code}};" value="{{color}}" {% if color == player.color %}selected{% endif %}>{{color.capitalize}}</option>
+          <option style="background-color: {{code}};" value="{{color}}" {% if code == player.color %}selected{% endif %}>{{color.capitalize}}</option>
           {% endfor %}
         </select>
       </td>

--- a/pbf/templates/setup.html
+++ b/pbf/templates/setup.html
@@ -34,7 +34,7 @@
       </td>
       <td>
         <select name="color" style="background-color: {{player.circle_color}};" onChange="this.style.backgroundColor = this.options[this.selectedIndex].style.backgroundColor">
-          {% for color, freq, code in player.game.color_freq %}
+          {% for color, freq, code in game.color_freq %}
           {# Probably not necessary to show in-use indicators. #}
           {# The host can see all the players in the table, #}
           {# so they are capable of making this judgment themselves. #}

--- a/pbf/templates/tabs.html
+++ b/pbf/templates/tabs.html
@@ -1,6 +1,6 @@
 <div class="tab-list mt-15">
-	{% for p in game.gameplayer_set.all %}
-	<a hx-get="{% url 'tab' game.id p.id %}" class="{% if p.id == player.id %}selected{% endif %}"><span style="color: {{p.circle_color}};">⬤</span> {% if p.aspect %}{{p.aspect}} {% endif %}{{p.spirit.name}}{% if p.name %} ({{p.name}}){% endif %}</a>
+	{% for p in game.player_summary %}
+	<a hx-get="{% url 'tab' game.id p.id %}" class="{% if p.id == player.id %}selected{% endif %}"><span style="color: {{p.color}};">⬤</span> {% if p.aspect %}{{p.aspect}} {% endif %}{{p.spirit__name}}{% if p.name %} ({{p.name}}){% endif %}</a>
 	{% endfor %}
 </div>
 

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -624,7 +624,7 @@ def view_game(request, game_id, spirit_spec=None):
 
         return redirect(reverse('view_game', args=[game.id, spirit_spec] if spirit_spec else [game.id]))
 
-    tab_id = try_match_spirit(game, spirit_spec) or (game.gameplayer_set.first().id if game.gameplayer_set.exists() else None)
+    tab_id = try_match_spirit(game, spirit_spec) or game.gameplayer_set.values_list('id', flat=True).first()
     logs = reversed(game.gamelog_set.order_by('-date').all()[:30])
     return render(request, 'game.html', { 'game': game, 'logs': logs, 'tab_id': tab_id, 'spirit_spec': spirit_spec })
 


### PR DESCRIPTION
We only need the full info of the player whose spirit panel we are actively showing. For all other players, we only need just enough info to display their tab.

Queries before this commit:

* one to check whether there are any players
* one (full info, unnecessary) to get the ID of the first player to show their tab
* three to count the number of players:
  * one to check if it's non-zero to decide whether to show tabs
  * two for the discard N cards from deck button
* one to show the full info of the current tab's player
* one (full info, unnecessary) to show the tab list

Queries after this commit:

* one to count the number of players
* one to get the ID of the first player to show their tab
* one to show the full info of the current tab's player
* one (summary) to show the tab list

Two duplicate queries and one redundant query have been removed entirely, and two that were previously getting full info now only get the info they need.

The two summary queries have to be separate because the tabs are a different HTTP request from the main game page and therefore can't share the same instance of Game.
Whether this is possible to resolve is for future investigation; it's outside the scope of this commit.