### PR TITLE
try_match_spirit: Only query for the ID, not other values

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -640,26 +640,26 @@ def try_match_spirit(game, spirit_spec):
         elif spirit_spec in player_ids:
             return spirit_spec
     else:
-        aspect_match = game.gameplayer_set.filter(aspect__iexact=spirit_spec)
-        if aspect_match.exists():
-            return aspect_match.first().id
+        aspect_match = game.gameplayer_set.filter(aspect__iexact=spirit_spec).values_list('id', flat=True).first()
+        if aspect_match:
+            return aspect_match
         # prefer the base spirit if they search for a spirit name,
         # in case there is one base and one aspected spirit in the same game.
-        base_spirit_match = game.gameplayer_set.filter(spirit__name__iexact=spirit_spec, aspect=None)
-        if base_spirit_match.exists():
-            return base_spirit_match.first().id
-        spirit_match = game.gameplayer_set.filter(spirit__name__iexact=spirit_spec)
-        if spirit_match.exists():
-            return spirit_match.first().id
+        base_spirit_match = game.gameplayer_set.filter(spirit__name__iexact=spirit_spec, aspect=None).values_list('id', flat=True).first()
+        if base_spirit_match:
+            return base_spirit_match
+        spirit_match = game.gameplayer_set.filter(spirit__name__iexact=spirit_spec).values_list('id', flat=True).first()
+        if spirit_match:
+            return spirit_match
 
         # look for an exact match first, in case someone's name is a substring of another
         # on the other hand, if someone's name is exactly a spirit or aspect's name, not much we can do!
-        player_exact_match = game.gameplayer_set.filter(name__iexact=spirit_spec)
-        if player_exact_match.exists():
-            return player_exact_match.first().id
-        player_match = game.gameplayer_set.filter(name__icontains=spirit_spec)
-        if player_match.exists():
-            return player_match.first().id
+        player_exact_match = game.gameplayer_set.filter(name__iexact=spirit_spec).values_list('id', flat=True).first()
+        if player_exact_match:
+            return player_exact_match
+        player_match = game.gameplayer_set.filter(name__icontains=spirit_spec).values_list('id', flat=True).first()
+        if player_match:
+            return player_match
 
 def draw_cards(request, game_id):
     game = get_object_or_404(Game, pk=game_id)


### PR DESCRIPTION
`first().id` loads the entire model, which is unnecessary because we only need the ID.

https://docs.djangoproject.com/en/5.2/ref/models/querysets/ explains that `first()` is one of the methods that doesn't return a `QuerySet`.

Instead, we should use `values_list` which creates a `QuerySet` that will return just the specified fields when evaluated.

This allows us to remove the unnecessary `exists()` query as well, since `first()` will return `None` if there are no matches, which is exactly the semantics we want, because that will cause us to try to use the next search criterion. Previously `first().id` would crash because of the `.id` lookup on a `None`.