### PR TITLE
models: fix Resilience Earth's thresholds (misspelled as Resilence)

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -587,7 +587,7 @@ spirit_thresholds = {
             (370, 480, '2S3E2P'),
             (370, 520, '2S4E3P'),
             ],
-        'ResilenceEarth': [
+        'ResilienceEarth': [
             (370, 440, '1S2E2P'),
             (370, 480, '2S3E2P'),
             (370, 520, '2S4E3P'),


### PR DESCRIPTION
Full accounting:
    
This was originally consistently misspelled everywhere as Resilence:
https://github.com/nathanj/spirit-island-pbp/commit/fcb940029e5a3fec9e9b03cc2dd825a05f3f7c1b 2022-02-06 (spirit)
https://github.com/nathanj/spirit-island-pbp/commit/c555715fa4dd0743a3add024d9ec5acf15730d49 2022-09-30 (thresholds)
this means everything worked because everything was using the same wrong spelling.

However, then when I reorganised spirits by expansion, I used the
correct spelling, not realising that it was previously incorrect:
https://github.com/nathanj/spirit-island-pbp/commit/086a539fe3c5bcdd4832399b8388fc2d513a0bd2 2024-09-28
https://github.com/nathanj/spirit-island-pbp/pull/61
At this point Resilience no longer has its aspect card image nor thresholds.

I discovered later on that the aspect image was missing:
https://github.com/nathanj/spirit-island-pbp/commit/c08ea678280c8348a9dd2726709fc51cb7a7bfef 2025-01-10
https://github.com/nathanj/spirit-island-pbp/pull/81

And only now do I discover that the thresholds need fixing as well.
