### PR TITLE
GamePlayer: cache cards in play

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -415,7 +415,7 @@ class GamePlayer(models.Model):
         if self.aspect in ('Dark Fire', 'Intensify'):
             counter[Elements.Moon] += 1
 
-        for card in self.play.all():
+        for card in self.cards_in_play:
             counter += card.get_elements()
         if self.spirit.name == 'Earthquakes':
             played_impending = self.impending_with_energy.filter(gameplayerimpendingwithenergy__in_play=True)
@@ -427,6 +427,10 @@ class GamePlayer(models.Model):
                 # Making a new field for Rot just seemed sort of wasteful.
                 counter.update(Elements[e] for e in presence.elements.split(',') if e != 'Rot')
         return defaultdict(int, counter)
+
+    @functools.cached_property
+    def cards_in_play(self):
+        return self.play.all()
 
     def equiv_elements(self):
         if self.aspect == 'Dark Fire': return "MF"
@@ -465,7 +469,7 @@ class GamePlayer(models.Model):
 
     def get_play_cost(self):
         blitz = self.game.scenario == 'Blitz'
-        return sum([card.cost - (1 if blitz and card.speed == Card.FAST else 0) for card in self.play.all()])
+        return sum([card.cost - (1 if blitz and card.speed == Card.FAST else 0) for card in self.cards_in_play])
 
     def get_gain_energy(self):
         energy_revealed = [p.energy for p in self.presences_off_track if p.energy]

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -955,7 +955,7 @@ def create_days(request, player_id, num):
 def compute_card_thresholds(player):
     equiv_elements = player.equiv_elements()
     player.play_cards = []
-    for card in player.play.all():
+    for card in player.cards_in_play:
         card.computed_thresholds = card.thresholds(player.elements, equiv_elements)
         player.play_cards.append(card)
     player.hand_cards = []
@@ -1111,6 +1111,8 @@ def reclaim_all(request, player_id):
 
 def discard_all(request, player_id):
     player = get_object_or_404(GamePlayer, pk=player_id)
+    # if we used the cached property cards_in_play here, we'd have to clear it,
+    # so let's just not use it.
     player.discard.add(*player.play.all())
 
     if player.spirit.name == 'Earthquakes':
@@ -1164,7 +1166,7 @@ def ready(request, player_id):
 
     if player.gained_this_turn:
         add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} gains {player.get_gain_energy()} energy')
-    for card in player.play.all():
+    for card in player.cards_in_play:
         add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} plays {card.name}')
     if player.spirit.name == 'Earthquakes':
         add_impending_log_msgs(player)


### PR DESCRIPTION
A typical page load will query cards in play three times:

* Once to calculate the total cost of cards in play
* Once to count all their elements
* Once to show them in the UI

Let's avoid two of these by caching it.