### PR TITLE
return_to_deck: add log message

### DIFF
--- a/pbf/views.py
+++ b/pbf/views.py
@@ -827,6 +827,8 @@ def return_to_deck(request, player_id, card_id):
     else:
         raise ValueError(f"Can't return {card}")
 
+    add_log_msg(game, text=f'{card.name} returned to the deck')
+
     compute_card_thresholds(player)
     return with_log_trigger(render(request, 'player.html', {'player': player}))
 


### PR DESCRIPTION
return_to_deck was added in c94624427aa351e2cfd8f00dce76640f149ecbde but no log message was added at that time.

Other actions that interact with the discard pile have since added logging:
Forget: b931cf331cf460289af5196cfc7a4c590cad0d29
Regain: 7a4a494f858023f04f22d9706e6e4b76ffb87495

Adding logging to returning to deck seems most consistent and helps everyone understand where a card might have gone.