### PR TITLE
add property, UI counter, and log message for Time

### DIFF
--- a/pbf/models.py
+++ b/pbf/models.py
@@ -529,6 +529,16 @@ class GamePlayer(models.Model):
     def days_ordered(self):
         return self.days.order_by('type', 'cost')
 
+    @functools.cached_property
+    def time(self):
+        # Time being tracked by presence discs was added before the general spirit_specific_resource was added.
+        # Tracking it via presence matches the physical game,
+        # but it may be confusing that this one spirit uses a different system.
+        # TODO: Should we switch Time to use spirit_specific_resource for uniformity?
+        # The other benefit is that it's more obvious how to add Time with +1 / -1 buttons,
+        # rather than having to know to click a specific area of the spirit panel.
+        return self.presence_set.filter(opacity=1.0, left__lte=300).count()
+
     def thresholds(self):
         elements = self.elements
         thresholds = []

--- a/pbf/templates/energy.html
+++ b/pbf/templates/energy.html
@@ -81,5 +81,9 @@
       {% endif %}
         </p>
   {% endif %}
+  {% if player.spirit.name == 'Fractured' %}
+  <p><abbr title="Click on the upper-left corner of the spirit panel to add Time">Time</abbr>: {{ player.time }}</p>
+  {% endif %}
+
 </div>
 

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -1175,6 +1175,8 @@ def ready(request, player_id):
     if player.paid_this_turn:
         add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} pays {player.get_play_cost()} energy')
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} started with {player.last_unready_energy_friendly} energy and now has {player.energy} energy')
+    if player.spirit.name == 'Fractured':
+        add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} has {player.time} Time')
     if player.has_spirit_specific_resource():
         add_spirit_specific_resource_msgs(player)
     add_log_msg(player.game, text=f'{player.circle_emoji} {player.spirit.name} is ready')


### PR DESCRIPTION
Just like how c05536dc168685ed09e1805bc3ebbf89a8357a87 added a log message for spirit-specific resources using the spirit_specific_resource property, let's add one for Time. Time was added before spirit_specific_resource, so it doesn't use that system.

To be decided at a later time is whether it makes sense to switch Time to using sprit_specific_resource.