### PR TITLE
remove spirit icon for Exploratory Bringer

### DIFF
--- a/pbf/static/pbf/spirit-icon-Exploratory Bringer.png
+++ b/pbf/static/pbf/spirit-icon-Exploratory Bringer.png
@@ -1,1 +1,0 @@
-spirit-icon-Bringer.png


### PR DESCRIPTION
this should have been removed alongside the rest of the exploratory Bringer materials in ea09430c6590dd45aef2419be8e6941c44643a19