### PR TITLE
README: use Pin Messages, not Manage Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The bot does not require any server-wide permissions, only permissions specific 
 * Optional: Use External Emoji (If you want the bot to use Spirit Island emoji on a server other than Spirit Island)
 * Optional: Add Reactions (If you want the bot to respond to commands via reactions instead of a separate message)
 * Optional: Read Message History (Enables commands like `$pin`, where the bot needs to access the message that the command is replying to)
-* Optional: Manage Messages (If you are comfortable allowing the bot to pin messages using the `$pin` command)
+* Optional: Pin Messages (If you are comfortable allowing the bot to pin messages using the `$pin` command)
 * Optional: Manage Channel (If you are comfortable allowing the bot to set the topic using the `$topic` command and rename the channel using the `$rename` command. **WARNING**: This permission also allows deleting the channel. While this bot will never do so, an attacker who acquires the bot's token will be able to use it to delete channels if given this permission.)
 
 Once you have the bot added to the server,


### PR DESCRIPTION
As of 2025-08-20, Discord has added Pin Messages as a new permission.

Manage Messages will still work until 2026-01-12, but we should not wait until the last minute to update the documentation.

https://discord.com/developers/docs/change-log?topic=HTTP+API#pin-permission-split