### PR TITLE
templates/player: separate the options with commas

### DIFF
--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -400,9 +400,9 @@
   <p>
   Direct link to spirit:
   {# Aesthetic preference: Don't use aspect for Covets Gleaming Shards of Earth (which we use to store the version). Using the aspect would work, but seems less clear. #}
-  <a href="{% if player.aspect and player.spirit.name != 'Covets' %}{% url 'view_game' player.game.id player.aspect %}{% else %}{% url 'view_game' player.game.id player.spirit.name %}{% endif %}">by spirit</a>
+  <a href="{% if player.aspect and player.spirit.name != 'Covets' %}{% url 'view_game' player.game.id player.aspect %}{% else %}{% url 'view_game' player.game.id player.spirit.name %}{% endif %}">by spirit</a>,
   {% if player.name %}
-  <a href="{% url 'view_game' player.game.id player.name %}">by player name</a>
+  <a href="{% url 'view_game' player.game.id player.name %}">by player name</a>,
   {% endif %}
   <a href="{% url 'view_game' player.game.id player.id %}">by ID</a>
   </p>


### PR DESCRIPTION
Otherwise, it's hard to tell where one ends and the other begins