### PR TITLE
admin: disable editing spirit

### DIFF
--- a/pbf/admin.py
+++ b/pbf/admin.py
@@ -21,6 +21,10 @@ class GamePlayerAdmin(admin.ModelAdmin):
     search_fields = ('game__id', 'name')
     search_help_text = 'Search by game ID or player name'
     list_display = ('id', 'game', 'spirit__name', 'aspect', 'name')
+    # Changing spirit doesn't change their hand or presence.
+    # Doing so via admin interface is not an operation we should offer,
+    # as offering it is an implicit promise that it works.
+    readonly_fields = ('spirit', )
     autocomplete_fields = ('hand', 'discard', 'play', 'selection', 'days')
 
     # Some fields are specific to one spirit and don't do anything for others.


### PR DESCRIPTION
This is not a supported operation. If you do this, it doesn't change either of these things:

* cards in hand
* presence

this leads to an inconsistent state that isn't representative of any spirit at all.

To avoid any impression that it's a supported operation, disable it.