### PR TITLE
import_game: allow imported presence to omit opacity/energy/elements

### DIFF
--- a/pbf/tests.py
+++ b/pbf/tests.py
@@ -1245,6 +1245,21 @@ class TestImport(TestCase):
         player = game.gameplayer_set.first()
         self.assertEqual(sum(player.presence_set.values_list('opacity', flat=True)), 11)
 
+    def test_import_presence_no_opacity(self):
+        game = self.import_game('{"players": [{"spirit": "River", "presence": [{"energy": "2"}]}]}')
+        player = game.gameplayer_set.first()
+        self.assertEqual(sum(player.presence_set.values_list('opacity', flat=True)), 12)
+
+    def test_import_presence_with_explicit_0_opacity(self):
+        game = self.import_game('{"players": [{"spirit": "River", "presence": [{"opacity": 0, "energy": "2"}]}]}')
+        player = game.gameplayer_set.first()
+        self.assertEqual(sum(player.presence_set.values_list('opacity', flat=True)), 11)
+
+    def test_import_presence_with_explicit_1_opacity(self):
+        game = self.import_game('{"players": [{"spirit": "Serpent", "aspect": "Locus", "presence": [{"opacity": 1, "elements": "Fire"}]}]}')
+        player = game.gameplayer_set.first()
+        self.assertEqual(sum(player.presence_set.values_list('opacity', flat=True)), 12)
+
     def test_import_card_dict(self):
         game = self.import_game('{"minor_deck": [{"name": "Call to Isolation"}]}')
         minor = Card.objects.get(name="Call to Isolation")

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -524,18 +524,25 @@ def import_game(request):
             expected_energy = expected_presence[3] if 3 < len(expected_presence) else ''
             expected_elements = expected_presence[4] if 4 < len(expected_presence) else ''
 
+            # opacity is respected if present, otherwise defaulted to the starting state
+            if import_presence and 'opacity' in import_presence:
+                opacity = import_presence['opacity']
+            elif gp.aspect == 'Locus' and i == 0:
+                opacity = 0.0
+            else:
+                opacity = expected_presence[2]
+
             if import_presence:
+                # energy and elements are checked to see if they match what's expected
                 # limitation: This will cause the import to fail if we change the order of spirits' presences.
                 # maybe it's better to also import the top/left coordinates.
                 # we aren't doing this yet because the API doesn't export them.
-                if import_presence['energy'] != expected_energy:
-                    raise ValueError(f"presence at {expected_presence[0]}, {expected_presence[1]} should have {expected_energy} energy but had {import_presence['energy']}")
-                if import_presence['elements'] != expected_elements:
-                    raise ValueError(f"presence at {expected_presence[0]}, {expected_presence[1]} should have {expected_elements} elements but had {import_presence['elements']}")
-                gp.presence_set.create(left=expected_presence[0], top=expected_presence[1], opacity=import_presence['opacity'], energy=import_presence['energy'], elements=import_presence['elements'])
-            else:
-                expected_opacity = 0.0 if gp.aspect == 'Locus' and i == 0 else expected_presence[2]
-                gp.presence_set.create(left=expected_presence[0], top=expected_presence[1], opacity=expected_opacity, energy=expected_energy, elements=expected_elements)
+                if import_presence.get('energy', '') != expected_energy:
+                    raise ValueError(f"presence at {expected_presence[0]}, {expected_presence[1]} should have {expected_energy} energy but had {import_presence.get('energy')}")
+                if import_presence.get('elements', '') != expected_elements:
+                    raise ValueError(f"presence at {expected_presence[0]}, {expected_presence[1]} should have {expected_elements} elements but had {import_presence.get('elements')}")
+
+            gp.presence_set.create(left=expected_presence[0], top=expected_presence[1], opacity=opacity, energy=expected_energy, elements=expected_elements)
 
         if 'hand' in player:
             gp.hand.set(hand := cards_with_name(player['hand']))

--- a/pbf/views.py
+++ b/pbf/views.py
@@ -520,7 +520,7 @@ def import_game(request):
                 available_colours = {color for (color, _) in GamePlayer.COLORS}
         gp.save()
 
-        for (i, (expected_presence, import_presence)) in enumerate(zip(spirit_presence[spirit_name], itertools.chain(player.get('presence', []), itertools.repeat(None)))):
+        for (expected_presence, import_presence) in zip(spirit_presence[spirit_name], itertools.chain(player.get('presence', []), itertools.repeat(None))):
             expected_energy = expected_presence[3] if 3 < len(expected_presence) else ''
             expected_elements = expected_presence[4] if 4 < len(expected_presence) else ''
 
@@ -531,7 +531,7 @@ def import_game(request):
             # opacity is respected if present, otherwise defaulted to the starting state
             if import_presence and 'opacity' in import_presence:
                 opacity = import_presence['opacity']
-            elif gp.aspect == 'Locus' and i == 0:
+            elif gp.aspect == 'Locus' and expected_elements == 'Fire':
                 opacity = 0.0
             else:
                 opacity = expected_presence[2]


### PR DESCRIPTION
opacity will be defaulted to its starting value. energy/elements will be checked against whether it's expected to be empty