### PR TITLE
admin: only change cards in debug

### DIFF
--- a/pbf/admin.py
+++ b/pbf/admin.py
@@ -1,9 +1,12 @@
+from django.conf import settings
 from django.contrib import admin
 from .models import *
 
 class CardAdmin(admin.ModelAdmin):
     def has_add_permission(self, request, obj=None):
         return False
+    def has_change_permission(self, request, obj=None):
+        return settings.DEBUG and super().has_change_permission(request, obj)
     def has_delete_permission(self, request, obj=None):
         return False
     search_fields = ('name',)


### PR DESCRIPTION
Cards are shared across all games. If anyone edits one, the change applies to all games. The admin interface, with no controls, is an inappropriate place to edit cards in production. To prevent corrupt data, we cannot allow it.

On the other hand, if someone really wants to corrupt their own data on their private debug instance, that's their own decision and they can deal with the consequences.