### PR TITLE
Add "not impended this turn" check to whether Earthquakes' impended cards show as playable.

### DIFF
--- a/pbf/templates/player.html
+++ b/pbf/templates/player.html
@@ -308,7 +308,7 @@
 	      </div>
 	      <div class="text-center pb-5">
 		    <button class="btn" hx-get="{% url 'add_energy_to_impending' player.id i.card.id %}" {% if i.in_play or i.energy >= i.cost_with_scenario %}disabled{% endif %}>+1</button>
-			{% if i.energy >= i.cost_with_scenario %}
+			{% if i.energy >= i.cost_with_scenario and not i.this_turn %}
 				{% if i.in_play %}
 					<button class="btn" hx-get="{% url 'unplay_from_impending' player.id i.card.id %}">Unplay</button>
 					{# No check of spirit_specific_resource_gives_energy since Dances Up Earthquakes doesn't have a spirit-specific resource #}


### PR DESCRIPTION
Adds a check to the UX for DUE's impended cards, so that cards impended this turn will not show as playable even if their energy requirements are fulfilled. Validated that they will still play from impending the following turn as expected 

<img width="549" height="498" alt="image" src="https://github.com/user-attachments/assets/64146a53-75ec-422f-80e6-9408f110d0dc" />

<img width="403" height="158" alt="image" src="https://github.com/user-attachments/assets/99e01a03-15c2-4cc0-b0b3-fe53f5e6f966" />

Closes #300 