### PR TITLE
bot: deprecate the pin and unpin (reply) commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ The bot does not require any server-wide permissions, only permissions specific 
 * Required: Attach Files
 * Optional: Use External Emoji (If you want the bot to use Spirit Island emoji on a server other than Spirit Island)
 * Optional: Add Reactions (If you want the bot to respond to commands via reactions instead of a separate message)
-* Optional: Read Message History (Enables commands like `$pin`, where the bot needs to access the message that the command is replying to)
-* Optional: Pin Messages (If you are comfortable allowing the bot to pin messages using the `$pin` command)
+* Optional: Read Message History (Enables commands like `$delete`, where the bot needs to access the message that the command is replying to)
+* Optional: Pin Messages (If you are comfortable allowing the bot to, as a convenience, perform the following functions)
+  * pin the game link in response to a `$follow` message
+  * unpin a number of messages in response to an `$unpin` message
 * Optional: Manage Channel (If you are comfortable allowing the bot to set the topic using the `$topic` command and rename the channel using the `$rename` command. **WARNING**: This permission also allows deleting the channel. While this bot will never do so, an attacker who acquires the bot's token will be able to use it to delete channels if given this permission.)
 
 Once you have the bot added to the server,


### PR DESCRIPTION
The admins of the main community using the bot have informed us that they've allowed hosts to pin messages under their own power, so the bot is no longer needed to serve this function.

However, unpin N is still useful as a convenience.

For an unspecified transitionary period, let's choose to still provide the pin functionality, but educate hosts that they can do so themselves.