### PR TITLE
update dependency gunicorn 25.3.0 -> 26.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # Although the site never imports Pillow, ImageField requires it.
     "Pillow>=12.0.0,<13",
     "django-ninja>=1.0.0,<2",
-    "gunicorn>=25.0.0,<26",
+    "gunicorn>=26.0.0,<27",
     "python-dotenv>=1.0.0,<2",
     "django-prometheus>=2.2.0,<3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -510,14 +510,14 @@ wheels = [
 
 [[package]]
 name = "gunicorn"
-version = "25.3.0"
+version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
 ]
 
 [[package]]
@@ -1082,7 +1082,7 @@ requires-dist = [
     { name = "django-cleanup", specifier = ">=9.0.0,<10" },
     { name = "django-ninja", specifier = ">=1.0.0,<2" },
     { name = "django-prometheus", specifier = ">=2.2.0,<3" },
-    { name = "gunicorn", specifier = ">=25.0.0,<26" },
+    { name = "gunicorn", specifier = ">=26.0.0,<27" },
     { name = "pillow", specifier = ">=12.0.0,<13" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2" },
 ]


### PR DESCRIPTION
https://github.com/benoitc/gunicorn/releases/tag/26.0.0

Released 2026-05-05

Test plan: Run the web server and make sure it serves